### PR TITLE
Avoid applying default `Content-Type: text/html; charset=utf-8` header

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -13,7 +13,7 @@ $app->get('/', function () {
     return new React\Http\Message\Response(
         200,
         [],
-        "Hello wörld!\n"
+        "Hello world!\n"
     );
 });
 
@@ -26,7 +26,7 @@ $app->get('/users/{name}', function (Psr\Http\Message\ServerRequestInterface $re
     return new React\Http\Message\Response(
         200,
         [
-            'Content-Type' => 'text/plain'
+            'Content-Type' => 'text/plain; charset=utf-8'
         ],
         "Hello " . $escape($request->getAttribute('name')) . "!\n"
     );

--- a/src/App.php
+++ b/src/App.php
@@ -260,17 +260,21 @@ class App
             $response = $response->withHeader('Content-Length', (string)$response->getBody()->getSize());
         }
 
-        // remove default "Content-Type" header set by PHP
+        // remove default "Content-Type" header set by PHP (default_mimetype)
         if (!$response->hasHeader('Content-Type')) {
             header('Content-Type: foo');
             header_remove('Content-Type');
         }
 
+        // send all headers without applying default "; charset=utf-8" set by PHP (default_charset)
+        $old = ini_get('default_charset');
+        ini_set('default_charset', '');
         foreach ($response->getHeaders() as $name => $values) {
             foreach ($values as $value) {
                 header($name . ': ' . $value);
             }
         }
+        ini_set('default_charset', $old);
 
         $body = $response->getBody();
 

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -13,9 +13,9 @@ skipif() {
     echo "$out" | grep "$@" >/dev/null && echo -n S && return 1 || return 0
 }
 
-out=$(curl -v $base/ 2>&1);         match "HTTP/.* 200"
-out=$(curl -v $base/test 2>&1);     match -i "Location: /"
-out=$(curl -v $base/invalid 2>&1);  match "HTTP/.* 404"
+out=$(curl -v $base/ 2>&1);         match "HTTP/.* 200" && match -iv "Content-Type:"
+out=$(curl -v $base/test 2>&1);     match -i "Location: /" && match -iP "Content-Type: text/html[\r\n]"
+out=$(curl -v $base/invalid 2>&1);  match "HTTP/.* 404" && match -iP "Content-Type: text/html[\r\n]"
 out=$(curl -v $base// 2>&1);        match "HTTP/.* 404"
 out=$(curl -v $base/ 2>&1 -X POST); match "HTTP/.* 405"
 
@@ -56,7 +56,7 @@ out=$(curl -v $base/query?q=a%00b 2>&1);                match "HTTP/.* 200" && m
 out=$(curl -v $base/query?q=a\&q=b 2>&1);               match "HTTP/.* 200" && match "{\"q\":\"b\"}"
 out=$(curl -v $base/query?q%5B%5D=a\&q%5B%5D=b 2>&1);   match "HTTP/.* 200" && match "{\"q\":[[]\"a\",\"b\"[]]}"
 
-out=$(curl -v $base/users/foo 2>&1);                    match "HTTP/.* 200" && match "Hello foo!"
+out=$(curl -v $base/users/foo 2>&1);                    match "HTTP/.* 200" && match "Hello foo!" && match -iP "Content-Type: text/plain; charset=utf-8[\r\n]"
 out=$(curl -v $base/users/w%C3%B6rld 2>&1);             match "HTTP/.* 200" && match "Hello wörld!"
 out=$(curl -v $base/users/w%F6rld 2>&1);                match "HTTP/.* 200" && match "Hello w�rld!" # demo expects UTF-8 instead of ISO-8859-1
 out=$(curl -v $base/users/a+b 2>&1);                    match "HTTP/.* 200" && match "Hello a+b!"


### PR DESCRIPTION
This changeset makes sure we do not apply a default `Content-Type: text/html; charset=utf-8` response header unless explicitly given. This covers existing behavior and additionally removes the default `; charset=utf-8` (or `default_charset`) parameter.

We may want to revisit this in the future to ensure we apply (more?) sensible defaults.

Builds on top of #3 and one step closer to #1