### PR TITLE
Use platform specific EOL constant for log tests

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -970,7 +970,7 @@ class AppTest extends TestCase
         $app = new App();
 
         // 2021-01-29 12:22:01.717 127.0.0.1 "GET /users HTTP/1.1" 200 6\n
-        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GET \/users HTTP\/1\.1\" 200 6\n$/");
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GET \/users HTTP\/1\.1\" 200 6" . PHP_EOL . "$/");
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
         $response = new Response(200, [], "Hello\n");
@@ -986,7 +986,7 @@ class AppTest extends TestCase
         $app = new App();
 
         // 2021-01-29 12:22:01.717 - "GET /users HTTP/1.1" 200 6\n
-        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} - \"GET \/users HTTP\/1\.1\" 200 6\n$/");
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} - \"GET \/users HTTP\/1\.1\" 200 6" . PHP_EOL . "$/");
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users');
         $response = new Response(200, [], "Hello\n");
@@ -1002,7 +1002,7 @@ class AppTest extends TestCase
         $app = new App();
 
         // 2021-01-29 12:22:01.717 Hello\n
-        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} Hello\n$/");
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} Hello" . PHP_EOL . "$/");
 
         // $app->log('Hello');
         $ref = new ReflectionMethod($app, 'log');


### PR DESCRIPTION
The following tests are failing if you run phpunit on windows
1) FrameworkX\Tests\AppTest::testLogRequestResponsePrintsRequestLogWithCurrentDateAndTime
Failed asserting that '2021-07-02 11:29:09.446 127.0.0.1 "GET /users HTTP/1.1" 200 6\r\n
' matches PCRE pattern "/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 "GET \/users HTTP\/1\.1" 200 6
$/".

2) FrameworkX\Tests\AppTest::testLogRequestResponseWithoutRemoteAddressPrintsRequestLogWithDashAsPlaceholder
Failed asserting that '2021-07-02 11:29:09.447 - "GET /users HTTP/1.1" 200 6\r\n
' matches PCRE pattern "/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} - "GET \/users HTTP\/1\.1" 200 6
$/".

3) FrameworkX\Tests\AppTest::testLogPrintsMessageWithCurrentDateAndTime
Failed asserting that '2021-07-02 11:29:09.448 Hello\r\n
' matches PCRE pattern "/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} Hello
$/".

The reason for this is that `PHP_EOL` uses "\r\n" on windows and not "\n" as expected by the test.

I'm not sure if logging output should have system specific line endings. As alternativ `PHP_EOL` can be replaced by "\n" in `App:log()`