### PR TITLE
Replace tcp: with http: in log message for while starting the SocketServer

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -210,7 +210,7 @@ class App
         $socket = new SocketServer(8080, $this->loop);
         $http->listen($socket);
 
-        $this->log('Listening on ' . $socket->getAddress());
+        $this->log('Listening on ' . \str_replace('tcp:', 'http:', $socket->getAddress()));
 
         $http->on('error', function (\Exception $e) {
             $orig = $e;
@@ -221,7 +221,7 @@ class App
 
             $this->log($message);
 
-            fwrite(STDERR, (string)$orig);
+            \fwrite(STDERR, (string)$orig);
         });
     }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -86,7 +86,7 @@ class AppTest extends TestCase
         $loop->expects($this->once())->method('run');
         $app = new App($loop);
 
-        $this->expectOutputRegex('/' . preg_quote('Listening on tcp://127.0.0.1:8080' . PHP_EOL, '/') . '$/');
+        $this->expectOutputRegex('/' . preg_quote('Listening on http://127.0.0.1:8080' . PHP_EOL, '/') . '$/');
         $app->run();
     }
 


### PR DESCRIPTION
Just a small improvement when starting the server.

This allows (at least for phpstorm and some terminals) to have a click able URI in the log output.

Additional use the global namespace for `fwrite` function. 