### PR TITLE
[RFC] PSR-11 Container support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
         "nikic/fast-route": "^1.3",
         "react/event-loop": "^1.2.0",
         "react/http": "^1.1",
-        "react/promise": "^2.7"
+        "react/promise": "^2.7",
+        "php-di/php-di": "^6.3.0",
+        "psr/log": "^1.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5 || ^7.5"


### PR DESCRIPTION
This is just a request for comments PR.

This implementation is a discussion starter for DI in fx, it replaces the `$loop` constructor variable with the `ContainerInterface`. I know this is a breaking change but keeping several legacy layers before a public release doesn't makes much sense and increases the maintenance effort.

I implemented also 2-3 example usages for the container.
1. `loop`
2. `logger`
3. `socketServerContext`

The `loop` entry is just a simple replacement for the existing `$loop` parameter.

The `logger` entry is a `LoggerInterface` defined by PSR-3 standard. It's used in the `log` function. Additional to this the request Logger supports now a `logger` attribute from the request. This can be used for context logging.

The `socketServerContext` is an array for the `socketServer` with on addition, it can hold a key named `uri` which is used for the `socketServer` `uri` parameter. This allows us to define a custom IP and port. Also we can use TLS and set custom parameters for the `socketServer`.

It adds 2 dependencies
1. php-di PSR-11
2. psr/log PSR-3

php-di brings a complete dependency injection package but required for other packages is only the `ContainerInterface`
psr/log brings only the PSR-3 `LoggerInterface`

Both dependencies are optional for applications based on fx.

Missing
- [X] Tested in a 3rd party application
- [ ] Documentation
- [ ] Tests
- [ ] Think about it

Just as remark this is just a discussion PR and should be a proof of concept.