### PR TITLE
Refactor to move access logging to new `AccessLogHandler`

### DIFF
--- a/src/AccessLogHandler.php
+++ b/src/AccessLogHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace FrameworkX;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use React\Promise\PromiseInterface;
+
+/**
+ * @internal
+ */
+class AccessLogHandler
+{
+    /** @var SapiHandler */
+    private $sapi;
+
+    public function __construct()
+    {
+        $this->sapi = new SapiHandler();
+    }
+
+    /**
+     * @return ResponseInterface|PromiseInterface<ResponseInterface>|\Generator
+     */
+    public function __invoke(ServerRequestInterface $request, callable $next)
+    {
+        $response = $next($request);
+
+        if ($response instanceof PromiseInterface) {
+            return $response->then(function (ResponseInterface $response) use ($request) {
+                $this->log($request, $response);
+                return $response;
+            });
+        } elseif ($response instanceof \Generator) {
+            return (function (\Generator $generator) use ($request) {
+                $response = yield from $generator;
+                $this->log($request, $response);
+                return $response;
+            })($response);
+        } else {
+            $this->log($request, $response);
+            return $response;
+        }
+    }
+
+    private function log(ServerRequestInterface $request, ResponseInterface $response): void
+    {
+        $this->sapi->log(
+            ($request->getServerParams()['REMOTE_ADDR'] ?? '-') . ' ' .
+            '"' . $request->getMethod() . ' ' . $request->getUri()->getPath() . ' HTTP/' . $request->getProtocolVersion() . '" ' .
+            $response->getStatusCode() . ' ' . $response->getBody()->getSize()
+        );
+    }
+}

--- a/src/SapiHandler.php
+++ b/src/SapiHandler.php
@@ -15,16 +15,9 @@ class SapiHandler
     /** @var resource */
     private $logStream;
 
-    /** @var bool */
-    private $shouldLogRequest;
-
     public function __construct()
     {
         $this->logStream = PHP_SAPI === 'cli' ? \fopen('php://output', 'a') : (\defined('STDERR') ? \STDERR : \fopen('php://stderr', 'a'));
-
-        // Only log for built-in webserver and PHP development webserver, others have their own access log.
-        // Yes, this should be moved out of this class.
-        $this->shouldLogRequest = PHP_SAPI === 'cli' || PHP_SAPI === 'cli-server';
     }
 
     public function requestFromGlobals(): ServerRequestInterface
@@ -124,19 +117,6 @@ class SapiHandler
         } else {
             echo $body;
         }
-    }
-
-    public function logRequestResponse(ServerRequestInterface $request, ResponseInterface $response): void
-    {
-        if (!$this->shouldLogRequest) {
-            return;
-        }
-
-        $this->log(
-            ($request->getServerParams()['REMOTE_ADDR'] ?? '-') . ' ' .
-            '"' . $request->getMethod() . ' ' . $request->getUri()->getPath() . ' HTTP/' . $request->getProtocolVersion() . '" ' .
-            $response->getStatusCode() . ' ' . $response->getBody()->getSize()
-        );
     }
 
     public function log(string $message): void

--- a/tests/AccessLogHandlerTest.php
+++ b/tests/AccessLogHandlerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace FrameworkX\Tests;
+
+use FrameworkX\AccessLogHandler;
+use PHPUnit\Framework\TestCase;
+use React\Http\Message\Response;
+use React\Http\Message\ServerRequest;
+use function React\Promise\resolve;
+
+class AccessLogHandlerTest extends TestCase
+{
+    public function testInvokePrintsRequestLogWithCurrentDateAndTime()
+    {
+        $handler = new AccessLogHandler();
+
+        $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
+        $response = new Response(200, [], "Hello\n");
+
+        // 2021-01-29 12:22:01.717 127.0.0.1 "GET /users HTTP/1.1" 200 6\n
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GET \/users HTTP\/1\.1\" 200 6" . PHP_EOL . "$/");
+        $handler($request, function () use ($response) { return $response; });
+    }
+
+    public function testInvokeWithDeferredNextPrintsRequestLogWithCurrentDateAndTime()
+    {
+        $handler = new AccessLogHandler();
+
+        $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
+        $response = new Response(200, [], "Hello\n");
+
+        // 2021-01-29 12:22:01.717 127.0.0.1 "GET /users HTTP/1.1" 200 6\n
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GET \/users HTTP\/1\.1\" 200 6" . PHP_EOL . "$/");
+        $handler($request, function () use ($response) { return resolve($response); });
+    }
+
+    public function testInvokeWithCoroutineNextPrintsRequestLogWithCurrentDateAndTime()
+    {
+        $handler = new AccessLogHandler();
+
+        $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
+        $response = new Response(200, [], "Hello\n");
+
+        $generator = $handler($request, function () use ($response) {
+            if (false) {
+                yield;
+            }
+            return $response;
+        });
+
+        /** @var \Generator $generator */
+        $this->assertInstanceOf(\Generator::class, $generator);
+
+        // 2021-01-29 12:22:01.717 127.0.0.1 "GET /users HTTP/1.1" 200 6\n
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GET \/users HTTP\/1\.1\" 200 6" . PHP_EOL . "$/");
+        $generator->next();
+    }
+
+    public function testInvokeWithoutRemoteAddressPrintsRequestLogWithDashAsPlaceholder()
+    {
+        $handler = new AccessLogHandler();
+
+        $request = new ServerRequest('GET', 'http://localhost:8080/users');
+        $response = new Response(200, [], "Hello\n");
+
+        // 2021-01-29 12:22:01.717 - "GET /users HTTP/1.1" 200 6\n
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} - \"GET \/users HTTP\/1\.1\" 200 6" . PHP_EOL . "$/");
+        $handler($request, function () use ($response) { return $response; });
+    }
+}

--- a/tests/AppMiddlewareTest.php
+++ b/tests/AppMiddlewareTest.php
@@ -16,7 +16,7 @@ class AppMiddlewareTest extends TestCase
 {
     public function testGetMethodWithMiddlewareAddsGetRouteOnRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function () {};
         $controller = function () { };
@@ -33,7 +33,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testHeadMethodWithMiddlewareAddsHeadRouteOnRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function () {};
         $controller = function () { };
@@ -50,7 +50,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testPostMethodWithMiddlewareAddsPostRouteOnRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function () {};
         $controller = function () { };
@@ -67,7 +67,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testPutMethodWithMiddlewareAddsPutRouteOnRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function () {};
         $controller = function () { };
@@ -84,7 +84,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testPatchMethodWithMiddlewareAddsPatchRouteOnRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function () {};
         $controller = function () { };
@@ -101,7 +101,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testDeleteMethodWithMiddlewareAddsDeleteRouteOnRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function () {};
         $controller = function () { };
@@ -118,7 +118,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testOptionsMethodWithMiddlewareAddsOptionsRouteOnRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function () {};
         $controller = function () { };
@@ -135,7 +135,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testAnyMethodWithMiddlewareAddsAllHttpMethodsOnRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function () {};
         $controller = function () { };
@@ -152,7 +152,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMapMethodWithMiddlewareAddsGivenMethodsOnRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function () {};
         $controller = function () { };
@@ -169,7 +169,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextReturnsResponseFromRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             return $next($request);
@@ -203,7 +203,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextWithModifiedRequestReturnsResponseFromRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             return $next($request->withAttribute('name', 'Alice'));
@@ -237,7 +237,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextReturnsResponseModifiedInMiddlewareFromRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             $response = $next($request);
@@ -272,7 +272,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextReturnsDeferredResponseModifiedInMiddlewareFromRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             $promise = $next($request);
@@ -317,7 +317,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextReturnsCoroutineResponseModifiedInMiddlewareFromRouter()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             $generator = $next($request);
@@ -364,7 +364,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextWhichThrowsExceptionReturnsInternalServerErrorResponse()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             return $next($request);
@@ -395,7 +395,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareWhichThrowsExceptionReturnsInternalServerErrorResponse()
     {
-        $app = new App();
+        $app = $this->createAppWithoutLogger();
 
         $line = __LINE__ + 2;
         $middleware = function (ServerRequestInterface $request, callable $next) {
@@ -424,7 +424,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareCallsNextReturnsResponseFromController()
     {
-        $app = new App(function (ServerRequestInterface $request, callable $next) {
+        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             return $next($request);
         });
 
@@ -454,7 +454,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareCallsNextWithModifiedRequestWillBeUsedForRouting()
     {
-        $app = new App(function (ServerRequestInterface $request, callable $next) {
+        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             return $next($request->withUri($request->getUri()->withPath('/users')));
         });
 
@@ -484,7 +484,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareCallsNextReturnsModifiedResponseWhenModifyingResponseFromRouter()
     {
-        $app = new App(function (ServerRequestInterface $request, callable $next) {
+        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             $response = $next($request);
             assert($response instanceof ResponseInterface);
 
@@ -515,7 +515,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareReturnsResponseWithoutCallingNextReturnsResponseWithoutCallingRouter()
     {
-        $app = new App(function () {
+        $app = $this->createAppWithoutLogger(function () {
             return new Response(
                 200,
                 [
@@ -548,7 +548,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareReturnsPromiseWhichResolvesWithResponseWithoutCallingNextDoesNotCallRouter()
     {
-        $app = new App(function () {
+        $app = $this->createAppWithoutLogger(function () {
             return resolve(new Response(
                 200,
                 [
@@ -589,7 +589,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareCallsNextReturnsPromiseWhichResolvesWithModifiedResponseWhenModifyingPromiseWhichResolvesToResponseFromRouter()
     {
-        $app = new App(function (ServerRequestInterface $request, callable $next) {
+        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             return $next($request)->then(function (ResponseInterface $response) {
                 return $response->withHeader('Content-Type', 'text/html');
             });
@@ -627,7 +627,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareCallsNextReturnsPromiseWhichResolvesWithModifiedResponseWhenModifyingCoroutineWhichYieldsResponseFromRouter()
     {
-        $app = new App(function (ServerRequestInterface $request, callable $next) {
+        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             $generator = $next($request);
             assert($generator instanceof \Generator);
 
@@ -667,5 +667,23 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('text/html', $response->getHeaderLine('Content-Type'));
         $this->assertEquals("OK\n", (string) $response->getBody());
+    }
+
+    private function createAppWithoutLogger(callable ...$middleware): App
+    {
+        $app = new App(...$middleware);
+
+        $ref = new \ReflectionProperty($app, 'handler');
+        $ref->setAccessible(true);
+        $middleware = $ref->getValue($app);
+
+        $ref = new \ReflectionProperty($middleware, 'handlers');
+        $ref->setAccessible(true);
+        $handlers = $ref->getValue($middleware);
+
+        unset($handlers[0]);
+        $ref->setValue($middleware, array_values($handlers));
+
+        return $app;
     }
 }

--- a/tests/SapiHandlerTest.php
+++ b/tests/SapiHandlerTest.php
@@ -152,44 +152,6 @@ class SapiHandlerTest extends TestCase
         $body->end('test');
     }
 
-    public function testLogRequestResponsePrintsRequestLogWithCurrentDateAndTime()
-    {
-        // 2021-01-29 12:22:01.717 127.0.0.1 "GET /users HTTP/1.1" 200 6\n
-        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GET \/users HTTP\/1\.1\" 200 6" . PHP_EOL . "$/");
-
-        $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
-        $response = new Response(200, [], "Hello\n");
-
-        $sapi = new SapiHandler();
-        $sapi->logRequestResponse($request, $response);
-    }
-
-    public function testLogRequestResponseWithoutRemoteAddressPrintsRequestLogWithDashAsPlaceholder()
-    {
-        // 2021-01-29 12:22:01.717 - "GET /users HTTP/1.1" 200 6\n
-        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} - \"GET \/users HTTP\/1\.1\" 200 6" . PHP_EOL . "$/");
-
-        $request = new ServerRequest('GET', 'http://localhost:8080/users');
-        $response = new Response(200, [], "Hello\n");
-
-        $sapi = new SapiHandler();
-        $sapi->logRequestResponse($request, $response);
-    }
-
-    public function testLogRequestResponseWithLogDisabledShouldNotPrintMessage()
-    {
-        $request = new ServerRequest('GET', 'http://localhost:8080/users');
-        $response = new Response(200, [], "Hello\n");
-
-        $sapi = new SapiHandler();
-        $ref = new \ReflectionProperty($sapi, 'shouldLogRequest');
-        $ref->setAccessible(true);
-        $ref->setValue($sapi, false);
-
-        $this->expectOutputString('');
-        $sapi->logRequestResponse($request, $response);
-    }
-
     public function testLogPrintsMessageWithCurrentDateAndTime()
     {
         // 2021-01-29 12:22:01.717 Hello\n


### PR DESCRIPTION
Builds on top of #44 and others
Refs #30 to prepare controlling access log behavior by passing in configured global middleware instead of DIC configuration