### PR TITLE
Improve `AccessLogHandler` to log full request target instead of path only

### DIFF
--- a/src/AccessLogHandler.php
+++ b/src/AccessLogHandler.php
@@ -47,8 +47,15 @@ class AccessLogHandler
     {
         $this->sapi->log(
             ($request->getServerParams()['REMOTE_ADDR'] ?? '-') . ' ' .
-            '"' . $request->getMethod() . ' ' . $request->getRequestTarget() . ' HTTP/' . $request->getProtocolVersion() . '" ' .
+            '"' . $this->escape($request->getMethod()) . ' ' . $this->escape($request->getRequestTarget()) . ' HTTP/' . $request->getProtocolVersion() . '" ' .
             $response->getStatusCode() . ' ' . $response->getBody()->getSize()
         );
+    }
+
+    private function escape(string $s): string
+    {
+        return preg_replace_callback('/[\x00-\x1F\x7F-\xFF"\\\\]+/', function (array $m) {
+            return str_replace('%', '\x', rawurlencode($m[0]));
+        }, $s);
     }
 }

--- a/tests/AccessLogHandlerTest.php
+++ b/tests/AccessLogHandlerTest.php
@@ -34,6 +34,19 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
+    public function testInvokePrintsRequestWithEscapedSpecialCharactersInRequestMethodAndTargetWithCurrentDateAndTime()
+    {
+        $handler = new AccessLogHandler();
+
+        $request = new ServerRequest('GE"T', 'http://localhost:8080/wörld', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
+        $request = $request->withRequestTarget('/wörld');
+        $response = new Response(200, [], "Hello\n");
+
+        // 2021-01-29 12:22:01.717 127.0.0.1 "GE\x22T /w\xC3\xB6rld HTTP/1.1" 200 6\n
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GE\\\\x22T \/w\\\\xC3\\\\xB6rld HTTP\/1\.1\" 200 6" . PHP_EOL . "$/");
+        $handler($request, function () use ($response) { return $response; });
+    }
+
     public function testInvokePrintsPlainProxyRequestLogWithCurrentDateAndTime()
     {
         $handler = new AccessLogHandler();


### PR DESCRIPTION
This changeset improves the `AccessLogHandler` to log the full request target instead of only the request path (without the query string). Additionally, fields containing special characters will now be escaped with bashslash escape sequences (like `\xFF`) similar to how [nginx](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format) and [Apache](https://httpd.apache.org/docs/2.4/mod/mod_log_config.html#formats) handle this.

Builds on top of #45 and #46