### PR TITLE
Show actual response size in access log for streaming response body

### DIFF
--- a/src/AccessLogHandler.php
+++ b/src/AccessLogHandler.php
@@ -5,6 +5,7 @@ namespace FrameworkX;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Promise\PromiseInterface;
+use React\Stream\ReadableStreamInterface;
 
 /**
  * @internal
@@ -28,27 +29,51 @@ class AccessLogHandler
 
         if ($response instanceof PromiseInterface) {
             return $response->then(function (ResponseInterface $response) use ($request) {
-                $this->log($request, $response);
+                $this->logWhenClosed($request, $response);
                 return $response;
             });
         } elseif ($response instanceof \Generator) {
             return (function (\Generator $generator) use ($request) {
                 $response = yield from $generator;
-                $this->log($request, $response);
+                $this->logWhenClosed($request, $response);
                 return $response;
             })($response);
         } else {
-            $this->log($request, $response);
+            $this->logWhenClosed($request, $response);
             return $response;
         }
     }
 
-    private function log(ServerRequestInterface $request, ResponseInterface $response): void
+    /**
+     * checks if response body is closed (not streaming) before writing log message for response
+     */
+    private function logWhenClosed(ServerRequestInterface $request, ResponseInterface $response): void
+    {
+        $body = $response->getBody();
+
+        if ($body instanceof ReadableStreamInterface && $body->isReadable()) {
+            $size = 0;
+            $body->on('data', function (string $chunk) use (&$size) {
+                $size += strlen($chunk);
+            });
+
+            $body->on('close', function () use (&$size, $request, $response) {
+                $this->log($request, $response, $size);
+            });
+        } else {
+            $this->log($request, $response, $body->getSize() ?? strlen((string) $body));
+        }
+    }
+
+    /**
+     * writes log message for response after response body is closed (not streaming anymore)
+     */
+    private function log(ServerRequestInterface $request, ResponseInterface $response, int $responseSize): void
     {
         $this->sapi->log(
             ($request->getServerParams()['REMOTE_ADDR'] ?? '-') . ' ' .
             '"' . $this->escape($request->getMethod()) . ' ' . $this->escape($request->getRequestTarget()) . ' HTTP/' . $request->getProtocolVersion() . '" ' .
-            $response->getStatusCode() . ' ' . $response->getBody()->getSize()
+            $response->getStatusCode() . ' ' . $responseSize
         );
     }
 


### PR DESCRIPTION
This changeset ensures we show the actual response size in the access log for a streaming response body.

Builds on top of #45, #46, #47