### PR TITLE
Show empty response body size in access log when response body MUST be empty

### DIFF
--- a/src/AccessLogHandler.php
+++ b/src/AccessLogHandler.php
@@ -75,10 +75,18 @@ class AccessLogHandler
      */
     private function log(ServerRequestInterface $request, ResponseInterface $response, int $responseSize, float $time): void
     {
+        $method = $request->getMethod();
+        $status = $response->getStatusCode();
+
+        // HEAD requests and `204 No Content` and `304 Not Modified` always use an empty response body
+        if ($method === 'HEAD' || $status === 204 || $status === 304) {
+            $responseSize = 0;
+        }
+
         $this->sapi->log(
             ($request->getServerParams()['REMOTE_ADDR'] ?? '-') . ' ' .
-            '"' . $this->escape($request->getMethod()) . ' ' . $this->escape($request->getRequestTarget()) . ' HTTP/' . $request->getProtocolVersion() . '" ' .
-            $response->getStatusCode() . ' ' . $responseSize . ' ' . sprintf('%.3F', $time < 0 ? 0 : $time)
+            '"' . $this->escape($method) . ' ' . $this->escape($request->getRequestTarget()) . ' HTTP/' . $request->getProtocolVersion() . '" ' .
+            $status . ' ' . $responseSize . ' ' . sprintf('%.3F', $time < 0 ? 0 : $time)
         );
     }
 

--- a/tests/AccessLogHandlerTest.php
+++ b/tests/AccessLogHandlerTest.php
@@ -48,6 +48,42 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
+    public function testInvokePrintsRequestLogForHeadRequestWithResponseSizeAsZero()
+    {
+        $handler = new AccessLogHandler();
+
+        $request = new ServerRequest('HEAD', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
+        $response = new Response(200, [], "HEAD\n");
+
+        // 2021-01-29 12:22:01.717 127.0.0.1 "HEAD /users HTTP/1.1" 200 0 0.000\n
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"HEAD \/users HTTP\/1\.1\" 200 0 0\.0\d\d" . PHP_EOL . "$/");
+        $handler($request, function () use ($response) { return $response; });
+    }
+
+    public function testInvokePrintsRequestLogForNoContentResponseWithResponseSizeAsZero()
+    {
+        $handler = new AccessLogHandler();
+
+        $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
+        $response = new Response(204, [], "No Content\n");
+
+        // 2021-01-29 12:22:01.717 127.0.0.1 "GET /users HTTP/1.1" 204 0 0.000\n
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GET \/users HTTP\/1\.1\" 204 0 0\.0\d\d" . PHP_EOL . "$/");
+        $handler($request, function () use ($response) { return $response; });
+    }
+
+    public function testInvokePrintsRequestLogForNotModifiedResponseWithResponseSizeAsZero()
+    {
+        $handler = new AccessLogHandler();
+
+        $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
+        $response = new Response(304, [], "Not Modified\n");
+
+        // 2021-01-29 12:22:01.717 127.0.0.1 "GET /users HTTP/1.1" 304 0 0.000\n
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GET \/users HTTP\/1\.1\" 304 0 0\.0\d\d" . PHP_EOL . "$/");
+        $handler($request, function () use ($response) { return $response; });
+    }
+
     public function testInvokePrintsPlainProxyRequestLogWithCurrentDateAndTime()
     {
         $handler = new AccessLogHandler();


### PR DESCRIPTION
This changeset ensures we always log an empty response body size in the access log when the response body MUST be empty, such as for `HEAD` requests, `204 No Content` and `304 Not Modified`.

```
2021-01-29 12:22:01.717 - "GET /users HTTP/1.1" 304 0 0.000
```

Builds on top of #45, #46, #47, #48, #49
Refs https://github.com/reactphp/http/pull/429