### PR TITLE
Skip sending body and `Content-Length` for responses with no body

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -110,6 +110,48 @@ $app->any('/method', function (ServerRequestInterface $request) {
     );
 });
 
+$app->get('/etag/', function (ServerRequestInterface $request) {
+    $etag = '"_"';
+    if ($request->getHeaderLine('If-None-Match') === $etag) {
+        return new React\Http\Message\Response(
+            304,
+            [
+                'ETag' => $etag
+            ],
+            ''
+        );
+    }
+
+    return new React\Http\Message\Response(
+        200,
+        [
+            'ETag' => $etag
+        ],
+        ''
+    );
+});
+$app->get('/etag/{etag:[a-z]+}', function (ServerRequestInterface $request) {
+    $etag = '"' . $request->getAttribute('etag') . '"';
+    if ($request->getHeaderLine('If-None-Match') === $etag) {
+        return new React\Http\Message\Response(
+            304,
+            [
+                'ETag' => $etag,
+                'Content-Length' => strlen($etag) - 1
+            ],
+            ''
+        );
+    }
+
+    return new React\Http\Message\Response(
+        200,
+        [
+            'ETag' => $etag
+        ],
+        $request->getAttribute('etag') . "\n"
+    );
+});
+
 $app->map(['GET', 'POST'], '/headers', function (ServerRequestInterface $request) {
     // Returns a JSON representation of all request headers passed to this endpoint.
     // Note that this assumes UTF-8 data in request headers and may break for other encodings,


### PR DESCRIPTION
This changeset ensures we explicitly skip any response body when the response body MUST be empty, such as for `HEAD` requests, `204 No Content` and `304 Not Modified`. Likewise, any streaming response body will be closed immediately in this case.

On top of this, X now ensures that `204 No Content` response never contains a `Content-Length` response header and `304 Not Modified` respects any explicit `Content-Length` header.

Builds on top of #50 and #48
Builds on top of https://github.com/reactphp/http/pull/429 and https://github.com/reactphp/http/pull/430
Refs https://github.com/tornadoweb/tornado/issues/1736 and https://github.com/ninenines/cowboy/issues/1153