### PR TITLE
Add instructions to specify port, if using Docker

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -95,6 +95,12 @@ this:
 $ php public/index.php
 ```
 
+Note: If you are using Docker, then run the example specifying the server port like this:
+
+```bash
+$ php -S 0.0.0.0:8080 public/index.php
+```
+
 You can now use your favorite web browser or command line tool to check your web
 application responds as expected:
 


### PR DESCRIPTION
If the running container is not mapped to any port, then not all requests would be able to pass through, unless the server is setup to expose the mentioned port (8080, in this case).