### PR TITLE
Accept class names instead of callables (DI container preparation)

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -111,9 +111,27 @@ you keep adding more controllers to a single application.
 For this reason, we recommend using [controller classes](../best-practices/controllers.md)
 for production use-cases like this:
 
-```php title="public/index.php"
-$app->get('/', new Acme\Todo\HelloController());
-```
+=== "Using controller instances"
+
+    ```php title="public/index.php"
+    <?php
+
+    // …
+
+    $app->get('/', new Acme\Todo\HelloController());
+    ```
+
+=== "Using controller names"
+
+    ```php title="public/index.php"
+    <?php
+
+    // …
+
+    $app->get('/', Acme\Todo\HelloController::class);
+    ```
+
+<!-- -->
 
 ```php title="src/HelloController.php"
 <?php

--- a/docs/api/middleware.md
+++ b/docs/api/middleware.md
@@ -81,16 +81,32 @@ class DemoMiddleware
     }
 }
 ```
-```php title="public/index.php"
-<?php
 
-use Acme\Todo\DemoMiddleware;
-use Acme\Todo\UserController;
+=== "Using middleware instances"
 
-// …
+    ```php title="public/index.php"
+    <?php
 
-$app->get('/user', new DemoMiddleware(), new UserController());
-```
+    use Acme\Todo\DemoMiddleware;
+    use Acme\Todo\UserController;
+
+    // …
+
+    $app->get('/user', new DemoMiddleware(), new UserController());
+    ```
+
+=== "Using middleware names"
+
+    ```php title="public/index.php"
+    <?php
+
+    use Acme\Todo\DemoMiddleware;
+    use Acme\Todo\UserController;
+
+    // …
+
+    $app->get('/user', DemoMiddleware::class, UserController::class);
+    ```
 
 This highlights how middleware classes provide the exact same functionaly as using inline functions,
 yet provide a cleaner and more reusable structure.
@@ -145,17 +161,31 @@ class UserController
 }
 ```
 
-```php
-# public/index.php
-<?php
+=== "Using middleware instances"
 
-use Acme\Todo\AdminMiddleware;
-use Acme\Todo\UserController;
+    ```php title="public/index.php"
+    <?php
 
-// …
+    use Acme\Todo\AdminMiddleware;
+    use Acme\Todo\UserController;
 
-$app->get('/user', new AdminMiddleware(), new UserController());
-```
+    // …
+
+    $app->get('/user', new AdminMiddleware(), new UserController());
+    ```
+
+=== "Using middleware names"
+
+    ```php title="public/index.php"
+    <?php
+
+    use Acme\Todo\AdminMiddleware;
+    use Acme\Todo\UserController;
+
+    // …
+
+    $app->get('/user', AdminMiddleware::class, UserController::class);
+    ```
 
 For example, an HTTP `GET` request for `/user` would first call the middleware handler which then modifies this request and passes the modified request to the next controller function.
 This is commonly used for HTTP authentication, login handling and session handling.
@@ -210,16 +240,31 @@ class UserController
 }
 ```
 
-```php title="public/index.php"
-<?php
+=== "Using middleware instances"
 
-use Acme\Todo\ContentTypeMiddleware;
-use Acme\Todo\UserController;
+    ```php title="public/index.php"
+    <?php
 
-// …
+    use Acme\Todo\ContentTypeMiddleware;
+    use Acme\Todo\UserController;
 
-$app->get('/user', new ContentTypeMiddleware(), new UserController());
-```
+    // …
+
+    $app->get('/user', new ContentTypeMiddleware(), new UserController());
+    ```
+
+=== "Using middleware names"
+
+    ```php title="public/index.php"
+    <?php
+
+    use Acme\Todo\ContentTypeMiddleware;
+    use Acme\Todo\UserController;
+
+    // …
+
+    $app->get('/user', ContentTypeMiddleware::class, UserController::class);
+    ```
 
 For example, an HTTP `GET` request for `/user` would first call the middleware handler which passes on the request to the controller function and then modifies the response that is returned by the controller function.
 This is commonly used for cache handling and response body transformations (compression etc.).
@@ -428,17 +473,33 @@ a response object synchronously:
     }
     ```
 
+<!-- -->
 
-```php title="public/index.php"
-<?php
+=== "Using middleware instances"
 
-use Acme\Todo\AsyncContentTypeMiddleware;
-use Acme\Todo\AsyncUserController;
+    ```php title="public/index.php"
+    <?php
 
-// …
+    use Acme\Todo\AsyncContentTypeMiddleware;
+    use Acme\Todo\AsyncUserController;
 
-$app->get('/user', new AsyncContentTypeMiddleware(), new AsyncUserController());
-```
+    // …
+
+    $app->get('/user', new AsyncContentTypeMiddleware(), new AsyncUserController());
+    ```
+
+=== "Using middleware names"
+
+    ```php title="public/index.php"
+    <?php
+
+    use Acme\Todo\AsyncContentTypeMiddleware;
+    use Acme\Todo\AsyncUserController;
+
+    // …
+
+    $app->get('/user', AsyncContentTypeMiddleware::class, AsyncUserController::class);
+    ```
 
 For example, an HTTP `GET` request for `/user` would first call the middleware handler which passes on the request to the controller function and then modifies the response that is returned by the controller function.
 This is commonly used for cache handling and response body transformations (compression etc.).
@@ -456,18 +517,35 @@ This is commonly used for cache handling and response body transformations (comp
 Additionally, you can also add middleware to the [`App`](app.md) object itself
 to register a global middleware handler:
 
-```php hl_lines="7" title="public/index.php"
-<?php
+=== "Using middleware instances"
 
-use Acme\Todo\AdminMiddleware;
-use Acme\Todo\UserController;
+    ```php hl_lines="6" title="public/index.php"
+    <?php
 
-$app = new FrameworkX\App(new AdminMiddleware());
+    use Acme\Todo\AsyncContentTypeMiddleware;
+    use Acme\Todo\AsyncUserController;
 
-$app->get('/user', new UserController());
+    $app = new FrameworkX\App(new AdminMiddleware());
 
-$app->run();
-```
+    $app->get('/user', new UserController());
+
+    $app->run();
+    ```
+
+=== "Using middleware names"
+
+    ```php hl_lines="6" title="public/index.php"
+    <?php
+
+    use Acme\Todo\AsyncContentTypeMiddleware;
+    use Acme\Todo\AsyncUserController;
+
+    $app = new FrameworkX\App(AdminMiddleware::class);
+
+    $app->get('/user', UserController::class);
+
+    $app->run();
+    ```
 
 Any global middleware handler will always be called for all registered routes
 and also any requests that can not be routed.

--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -40,18 +40,37 @@ For real-world applications, we highly recommend structuring your application
 into individual controller classes. This way, we can break up the above
 definition into three even simpler files:
 
-```php title="public/index.php"
-<?php
+=== "Using controller instances"
 
-require __DIR__ . '/../vendor/autoload.php';
+    ```php title="public/index.php"
+    <?php
 
-$app = new FrameworkX\App();
+    require __DIR__ . '/../vendor/autoload.php';
 
-$app->get('/', new Acme\Todo\HelloController());
-$app->get('/users/{name}', new Acme\Todo\UserController());
+    $app = new FrameworkX\App();
 
-$app->run();
-```
+    $app->get('/', new Acme\Todo\HelloController());
+    $app->get('/users/{name}', new Acme\Todo\UserController());
+
+    $app->run();
+    ```
+
+=== "Using controller names"
+
+    ```php title="public/index.php"
+    <?php
+
+    require __DIR__ . '/../vendor/autoload.php';
+
+    $app = new FrameworkX\App();
+
+    $app->get('/', Acme\Todo\HelloController::class);
+    $app->get('/users/{name}', Acme\Todo\UserController::class);
+
+    $app->run();
+    ```
+
+<!-- -->
 
 ```php title="src/HelloController.php"
 <?php

--- a/src/App.php
+++ b/src/App.php
@@ -33,9 +33,9 @@ class App
      * $app = new App($middleware1, $middleware2);
      * ```
      *
-     * @param callable ...$middleware
+     * @param callable|class-string ...$middleware
      */
-    public function __construct(callable ...$middleware)
+    public function __construct(...$middleware)
     {
         $errorHandler = new ErrorHandler();
         $this->router = new RouteHandler();
@@ -53,51 +53,103 @@ class App
         $this->sapi = new SapiHandler();
     }
 
-    public function get(string $route, callable $handler, callable ...$handlers): void
+    /**
+     * @param string $route
+     * @param callable|class-string $handler
+     * @param callable|class-string ...$handlers
+     */
+    public function get(string $route, $handler, ...$handlers): void
     {
         $this->map(['GET'], $route, $handler, ...$handlers);
     }
 
-    public function head(string $route, callable $handler, callable ...$handlers): void
+    /**
+     * @param string $route
+     * @param callable|class-string $handler
+     * @param callable|class-string ...$handlers
+     */
+    public function head(string $route, $handler, ...$handlers): void
     {
         $this->map(['HEAD'], $route, $handler, ...$handlers);
     }
 
-    public function post(string $route, callable $handler, callable ...$handlers): void
+    /**
+     * @param string $route
+     * @param callable|class-string $handler
+     * @param callable|class-string ...$handlers
+     */
+    public function post(string $route, $handler, ...$handlers): void
     {
         $this->map(['POST'], $route, $handler, ...$handlers);
     }
 
-    public function put(string $route, callable $handler, callable ...$handlers): void
+    /**
+     * @param string $route
+     * @param callable|class-string $handler
+     * @param callable|class-string ...$handlers
+     */
+    public function put(string $route, $handler, ...$handlers): void
     {
         $this->map(['PUT'], $route, $handler, ...$handlers);
     }
 
-    public function patch(string $route, callable $handler, callable ...$handlers): void
+    /**
+     * @param string $route
+     * @param callable|class-string $handler
+     * @param callable|class-string ...$handlers
+     */
+    public function patch(string $route, $handler, ...$handlers): void
     {
         $this->map(['PATCH'], $route, $handler, ...$handlers);
     }
 
-    public function delete(string $route, callable $handler, callable ...$handlers): void
+    /**
+     * @param string $route
+     * @param callable|class-string $handler
+     * @param callable|class-string ...$handlers
+     */
+    public function delete(string $route, $handler, ...$handlers): void
     {
         $this->map(['DELETE'], $route, $handler, ...$handlers);
     }
 
-    public function options(string $route, callable $handler, callable ...$handlers): void
+    /**
+     * @param string $route
+     * @param callable|class-string $handler
+     * @param callable|class-string ...$handlers
+     */
+    public function options(string $route, $handler, ...$handlers): void
     {
         $this->map(['OPTIONS'], $route, $handler, ...$handlers);
     }
 
-    public function any(string $route, callable $handler, callable ...$handlers): void
+    /**
+     * @param string $route
+     * @param callable|class-string $handler
+     * @param callable|class-string ...$handlers
+     */
+    public function any(string $route, $handler, ...$handlers): void
     {
         $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $route, $handler, ...$handlers);
     }
 
-    public function map(array $methods, string $route, callable $handler, callable ...$handlers): void
+    /**
+     *
+     * @param string[] $methods
+     * @param string $route
+     * @param callable|class-string $handler
+     * @param callable|class-string ...$handlers
+     */
+    public function map(array $methods, string $route, $handler, ...$handlers): void
     {
         $this->router->map($methods, $route, $handler, ...$handlers);
     }
 
+    /**
+     * @param string $route
+     * @param string $target
+     * @param int $code
+     */
     public function redirect(string $route, string $target, int $code = 302): void
     {
         $this->any($route, new RedirectHandler($target, $code));

--- a/tests/MiddlewareHandlerTest.php
+++ b/tests/MiddlewareHandlerTest.php
@@ -39,6 +39,38 @@ class MiddlewareHandlerTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
+    public function testOneMiddlewareClass()
+    {
+        $middleware = new class{
+            public function __invoke(ServerRequestInterface $request, callable $next) {
+                return $next($request);
+            }
+        };
+
+        $handler = new MiddlewareHandler([
+            $middleware,
+            function (ServerRequestInterface $request) {
+                return new Response(
+                    200,
+                    [
+                        'Content-Type' => 'text/html'
+                    ],
+                    "OK\n"
+                );
+            }
+        ]);
+
+        $request = new ServerRequest('GET', 'http://localhost/');
+
+        $response = $handler($request);
+
+        /** @var ResponseInterface $response */
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/html', $response->getHeaderLine('Content-Type'));
+        $this->assertEquals("OK\n", (string) $response->getBody());
+    }
+
     public function testTwoMiddleware()
     {
         $handler = new MiddlewareHandler([


### PR DESCRIPTION
This changeset adds support for using class names instead of class instances (callables). This prepares the API for a full dependency inject container (DIC) integration which is left up to follow-up PR (see also #30). Accordingly, this version only supports loading classes that have no required constructor arguments. This does not otherwise break existing APIs, so this is a pure feature addition.