### PR TITLE
Refactor: use $_SERVER instead of getenv()

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -172,10 +172,7 @@ class App
             return $this->handleRequest($request);
         });
 
-        $listen = \getenv('X_LISTEN');
-        if ($listen === false) {
-            $listen = '127.0.0.1:8080';
-        }
+        $listen = $_SERVER['X_LISTEN'] ?? '127.0.0.1:8080';
 
         $socket = new SocketServer($listen);
         $http->listen($socket);


### PR DESCRIPTION
The current implementation does not permit storing the default address to listen to, as it is hardcoded. 

By using `$_SERVER` instead of `getenv()` to check for the `X_LISTEN` env var, one could use a dotenv library such as `symfony/dotenv` to read `.env` files and populate `X_LISTEN`.

This could help devs override the default port to listen to (in case something else already use 127.0.0.1:8080 in their projects), and override the default port in their `.env.local`.

Example here: https://github.com/bpolaszek/freddie/blob/main/.env.test#L11 (this actually doesn't work and I had to specify the "real" env var in the CI)