### PR TITLE
Expose `Container` API to allow explicit DI container configuration

### DIFF
--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -205,15 +205,53 @@ constructor with type definitions to explicitly reference other classes.
 
 ### Container configuration
 
-> ⚠️ **Feature preview**
->
-> This is a feature preview, i.e. it might not have made it into the current beta.
-> Give feedback to help us prioritize.
-> We also welcome [contributors](../getting-started/community.md) to help out!
-
 Autowiring should cover most common use cases with zero configuration. If you
 want to have more control over this behavior, you may also explicitly configure
-the dependency injection container. This can be useful in these cases:
+the dependency injection container like this:
+
+=== "Arrow functions (PHP 7.4+)" 
+
+    ```php title="public/index.php"
+    <?php
+
+    require __DIR__ . '/../vendor/autoload.php';
+
+    $container = new FrameworkX\Container([
+        Acme\Todo\HelloController::class => fn() => new Acme\Todo\HelloController();
+    ]);
+
+
+
+    $app = new FrameworkX\App($container);
+
+    $app->get('/', Acme\Todo\HelloController::class);
+    $app->get('/users/{name}', Acme\Todo\UserController::class);
+
+    $app->run();
+    ```
+
+=== "Closure" 
+
+    ```php title="public/index.php"
+    <?php
+
+    require __DIR__ . '/../vendor/autoload.php';
+
+    $container = new FrameworkX\Container([
+        Acme\Todo\HelloController::class => function () {
+            return new Acme\Todo\HelloController();
+        }
+    ]);
+
+    $app = new FrameworkX\App($container);
+
+    $app->get('/', Acme\Todo\HelloController::class);
+    $app->get('/users/{name}', Acme\Todo\UserController::class);
+
+    $app->run();
+    ```
+
+This can be useful in these cases:
 
 * Constructor parameter references an interface and you want to explicitly
   define an instance that implements this interface.
@@ -221,6 +259,19 @@ the dependency injection container. This can be useful in these cases:
   etc.) or has no type at all and you want to explicitly bind a given value.
 * Constructor parameter references a class, but you want to inject a specific
   instance or subclass in place of a default class.
+
+The configured container instance can be passed into the application like any
+other middleware request handler. In most cases this means you create a single
+`Container` instance with a number of factory methods and pass this instance as
+the first argument to the `App`.
+
+### PSR-11 compatibility
+
+> ⚠️ **Feature preview**
+>
+> This is a feature preview, i.e. it might not have made it into the current beta.
+> Give feedback to help us prioritize.
+> We also welcome [contributors](../getting-started/community.md) to help out!
 
 In the future, we will also allow you to pass in a custom
 [PSR-11: Container interface](https://www.php-fig.org/psr/psr-11/) implementing

--- a/src/Container.php
+++ b/src/Container.php
@@ -9,10 +9,10 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class Container
 {
-    /** @var array<class-string,object> */
+    /** @var array<class-string,object|callable():object> */
     private $container;
 
-    /** @var array<class-string,object> */
+    /** @var array<class-string,callable():object | object> */
     public function __construct(array $map = [])
     {
         $this->container = $map;
@@ -80,6 +80,10 @@ class Container
     private function load(string $name, int $depth = 64)
     {
         if (isset($this->container[$name])) {
+            if ($this->container[$name] instanceof \Closure) {
+                $this->container[$name] = ($this->container[$name])();
+            }
+
             return $this->container[$name];
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -5,12 +5,18 @@ namespace FrameworkX;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * @internal
+ * @final
  */
 class Container
 {
     /** @var array<class-string,object> */
     private $container;
+
+    /** @var array<class-string,object> */
+    public function __construct(array $map = [])
+    {
+        $this->container = $map;
+    }
 
     public function __invoke(ServerRequestInterface $request, callable $next = null)
     {
@@ -30,7 +36,8 @@ class Container
 
     /**
      * @param class-string $class
-     * @return callable
+     * @return callable(ServerRequestInterface,?callable=null)
+     * @internal
      */
     public function callable(string $class): callable
     {

--- a/src/Container.php
+++ b/src/Container.php
@@ -12,6 +12,22 @@ class Container
     /** @var array<class-string,object> */
     private $container;
 
+    public function __invoke(ServerRequestInterface $request, callable $next = null)
+    {
+        if ($next === null) {
+            // You don't want to end up here. This only happens if you use the
+            // container as a final request handler instead of as a middleware.
+            // In this case, you should omit the container or add another final
+            // request handler behind the container in the middleware chain.
+            throw new \BadMethodCallException('Container should not be used as final request handler');
+        }
+
+        // If the container is used as a middleware, simply forward to the next
+        // request handler. As an additional optimization, the container would
+        // usually be filtered out from a middleware chain as this is a NO-OP.
+        return $next($request);
+    }
+
     /**
      * @param class-string $class
      * @return callable

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FrameworkX\Tests;
+
+use PHPUnit\Framework\TestCase;
+use FrameworkX\Container;
+use React\Http\Message\Response;
+use React\Http\Message\ServerRequest;
+
+class ContainerTest extends TestCase
+{
+    public function testInvokeContainerAsMiddlewareReturnsFromNextRequestHandler()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/http://localhost/');
+        $response = new Response(200, [], '');
+
+        $container = new Container();
+        $ret = $container($request, function () use ($response) { return $response; });
+
+        $this->assertSame($response, $ret);
+    }
+
+    public function testInvokeContainerAsFinalRequestHandlerThrows()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $container = new Container();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Container should not be used as final request handler');
+        $container($request);
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2,16 +2,70 @@
 
 namespace FrameworkX\Tests;
 
-use PHPUnit\Framework\TestCase;
 use FrameworkX\Container;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 use React\Http\Message\ServerRequest;
 
 class ContainerTest extends TestCase
 {
+    public function testCallableReturnsCallableForClassNameViaAutowiring()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $controller = new class {
+            public function __invoke(ServerRequestInterface $request)
+            {
+                return new Response(200);
+            }
+        };
+
+        $container = new Container();
+
+        $callable = $container->callable(get_class($controller));
+        $this->assertInstanceOf(\Closure::class, $callable);
+
+        $response = $callable($request);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testCallableReturnsCallableForClassNameViaAutowiringWithConfigurationForDependency()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $controller = new class(new \stdClass()) {
+            private $data;
+
+            public function __construct(\stdClass $data)
+            {
+                $this->data = $data;
+            }
+
+            public function __invoke(ServerRequestInterface $request)
+            {
+                return new Response(200, [], json_encode($this->data));
+            }
+        };
+
+        $container = new Container([
+            \stdClass::class => (object)['name' => 'Alice']
+        ]);
+
+        $callable = $container->callable(get_class($controller));
+        $this->assertInstanceOf(\Closure::class, $callable);
+
+        $response = $callable($request);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
+    }
+
     public function testInvokeContainerAsMiddlewareReturnsFromNextRequestHandler()
     {
-        $request = new ServerRequest('GET', 'http://example.com/http://localhost/');
+        $request = new ServerRequest('GET', 'http://example.com/');
         $response = new Response(200, [], '');
 
         $container = new Container();


### PR DESCRIPTION
This changeset exposes the `Container` API to allow explicit DI container configuration. This allows us to fine-tune the autowiring behavior and explicitly overwrite autowiring defaults for more advanced use cases. This does not otherwise break existing APIs, so this is a pure feature addition.

```php
<?php

require __DIR__ . '/../vendor/autoload.php';

$container = new FrameworkX\Container([
    Acme\Todo\HelloController::class => fn() => new Acme\Todo\HelloController();
]);

$app = new FrameworkX\App($container);

$app->get('/', Acme\Todo\HelloController::class);
$app->get('/users/{name}', Acme\Todo\UserController::class);

$app->run();
```

PSR-11 compatibility is one the roadmap, but left up for a follow-up PR.

Builds on top of #94 and #92