### PR TITLE
Update mkdocs-material to v8.1.3

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ If you want to contribute to the documentation, it's easiest to just run
 this in a Docker container in the project root directory like this:
 
 ```bash
-$ docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material:7.3.6
+$ docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material:8.1.3
 ```
 
 You can access the documentation via `http://localhost:8000`.
@@ -29,7 +29,7 @@ If you want to generate a static HTML folder for deployment, you can again
 use a Docker container in the project root directory like this:
 
 ```bash
-$ docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material:7.3.6 build
+$ docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material:8.1.3 build
 ```
 
 The resulting `build/docs/` should then be deployed behind a web server.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,6 @@
 site_name: Framework X documentation
 site_url: https://framework-x.org/docs/
 site_dir: build/docs
-extra:
-  homepage: ../
 
 repo_url: https://github.com/clue/framework-x
 repo_name: clue/framework-x
@@ -16,7 +14,8 @@ theme:
     repo: fontawesome/brands/github
 
 markdown_extensions:
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true 
   - pymdownx.highlight
   - pymdownx.superfences
   - toc:


### PR DESCRIPTION
Time to update Material for MkDocs! :tada: 

The docs don't change noticeably, but this allows us to look into code annotations in the future.

See https://squidfunk.github.io/mkdocs-material/upgrade/#upgrading-from-7x-to-8x
Builds on top of #55