### PR TITLE
Automatically start new fiber for each request on PHP 8.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "react/promise": "^2.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5 || ^7.5"
+        "phpunit/phpunit": "^9.5 || ^7.5",
+        "react/async": "^4@dev || ^3@dev"
     },
     "autoload": {
         "psr-4": {

--- a/examples/index.php
+++ b/examples/index.php
@@ -24,6 +24,22 @@ $app->get('/users/{name}', function (Psr\Http\Message\ServerRequestInterface $re
     );
 });
 
+$app->get('/sleep/promise', function () {
+    return React\Promise\Timer\sleep(0.1)->then(function () {
+        return React\Http\Message\Response::plaintext("OK\n");
+    });
+});
+$app->get('/sleep/coroutine', function () {
+    yield React\Promise\Timer\sleep(0.1);
+    return React\Http\Message\Response::plaintext("OK\n");
+});
+if (PHP_VERSION_ID >= 80100 && function_exists('React\Async\async')) { // requires PHP 8.1+ with react/async 4+
+    $app->get('/sleep/fiber', function () {
+        React\Async\await(React\Promise\Timer\sleep(0.1));
+        return React\Http\Message\Response::plaintext("OK\n");
+    });
+}
+
 $app->get('/uri[/{path:.*}]', function (ServerRequestInterface $request) {
     return React\Http\Message\Response::plaintext(
         (string) $request->getUri() . "\n"

--- a/src/App.php
+++ b/src/App.php
@@ -52,12 +52,17 @@ class App
             }
         }
 
-        // new MiddlewareHandler([$accessLogHandler, $errorHandler, ...$middleware, $routeHandler])
+        // new MiddlewareHandler([$fiberHandler, $accessLogHandler, $errorHandler, ...$middleware, $routeHandler])
         \array_unshift($middleware, $errorHandler);
 
         // only log for built-in webserver and PHP development webserver by default, others have their own access log
         if (\PHP_SAPI === 'cli' || \PHP_SAPI === 'cli-server') {
             \array_unshift($middleware, new AccessLogHandler());
+        }
+
+        // automatically start new fiber for each request on PHP 8.1+
+        if (\PHP_VERSION_ID >= 80100) {
+            \array_unshift($middleware, new FiberHandler()); // @codeCoverageIgnore
         }
 
         $this->router = new RouteHandler($container);

--- a/src/FiberHandler.php
+++ b/src/FiberHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace FrameworkX;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use React\Promise\Deferred;
+use React\Promise\Promise;
+use React\Promise\PromiseInterface;
+
+/**
+ * [Internal] Fibers middleware handler to ensure each request is processed in a separate `Fiber`
+ *
+ * The `Fiber` class has been added in PHP 8.1+, so this middleware is only used
+ * on PHP 8.1+. On supported PHP versions, this middleware is automatically
+ * added to the list of middleware handlers, so there's no need to reference
+ * this class in application code.
+ *
+ * @internal
+ * @link https://framework-x.org/docs/async/fibers/
+ */
+class FiberHandler
+{
+    /**
+     * @return PromiseInterface<ResponseInterface,void>
+     *     Returns a promise that is fulfilled with a `ResponseInterface` on
+     *     success. This method never throws or resolves a rejected promise.
+     *     If the request can not be routed or the handler fails, it will be
+     *     turned into a valid error response before returning.
+     * @throws void
+     */
+    public function __invoke(ServerRequestInterface $request, callable $next): PromiseInterface
+    {
+        return new Promise(function ($resolve) use ($next, $request) {
+            $fiber = new \Fiber(function () use ($resolve, $next, $request) {
+                $response = $next($request);
+                if ($response instanceof \Generator) {
+                    $response = $this->coroutine($response);
+                }
+
+                $resolve($response);
+            });
+            $fiber->start();
+        });
+    }
+
+    private function coroutine(\Generator $generator): PromiseInterface
+    {
+        $next = null;
+        $deferred = new Deferred();
+        $next = function () use ($generator, &$next, $deferred) {
+            if (!$generator->valid()) {
+                $deferred->resolve($generator->getReturn());
+                return;
+            }
+
+            $promise = $generator->current();
+            $promise->then(function ($value) use ($generator, $next) {
+                $generator->send($value);
+                $next();
+            }, function ($reason) use ($generator, $next) {
+                $generator->throw($reason);
+                $next();
+            });
+        };
+
+        $next();
+
+        return $deferred->promise();
+    }
+}

--- a/tests/AppMiddlewareTest.php
+++ b/tests/AppMiddlewareTest.php
@@ -171,7 +171,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextReturnsResponseFromRouter()
     {
-        $app = $this->createAppWithoutFibersOrLogger();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             return $next($request);
@@ -205,7 +205,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextWithModifiedRequestReturnsResponseFromRouter()
     {
-        $app = $this->createAppWithoutFibersOrLogger();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             return $next($request->withAttribute('name', 'Alice'));
@@ -239,7 +239,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextReturnsResponseModifiedInMiddlewareFromRouter()
     {
-        $app = $this->createAppWithoutFibersOrLogger();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             $response = $next($request);
@@ -366,7 +366,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareCallsNextWhichThrowsExceptionReturnsInternalServerErrorResponse()
     {
-        $app = $this->createAppWithoutFibersOrLogger();
+        $app = $this->createAppWithoutLogger();
 
         $middleware = function (ServerRequestInterface $request, callable $next) {
             return $next($request);
@@ -397,7 +397,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testMiddlewareWhichThrowsExceptionReturnsInternalServerErrorResponse()
     {
-        $app = $this->createAppWithoutFibersOrLogger();
+        $app = $this->createAppWithoutLogger();
 
         $line = __LINE__ + 2;
         $middleware = function (ServerRequestInterface $request, callable $next) {
@@ -426,7 +426,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareCallsNextReturnsResponseFromController()
     {
-        $app = $this->createAppWithoutFibersOrLogger(function (ServerRequestInterface $request, callable $next) {
+        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             return $next($request);
         });
 
@@ -463,7 +463,7 @@ class AppMiddlewareTest extends TestCase
             }
         };
 
-        $app = $this->createAppWithoutFibersOrLogger($middleware);
+        $app = $this->createAppWithoutLogger($middleware);
 
         $app->get('/', function () {
             return new Response(
@@ -498,7 +498,7 @@ class AppMiddlewareTest extends TestCase
             }
         };
 
-        $app = $this->createAppWithoutFibersOrLogger(get_class($middleware));
+        $app = $this->createAppWithoutLogger(get_class($middleware));
 
         $app->get('/', function () {
             return new Response(
@@ -534,7 +534,7 @@ class AppMiddlewareTest extends TestCase
             }
         };
 
-        $app = $this->createAppWithoutFibersOrLogger(get_class($middleware));
+        $app = $this->createAppWithoutLogger(get_class($middleware));
 
         $app->get('/', get_class($middleware), function (ServerRequestInterface $request) {
             return new Response(
@@ -562,7 +562,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareCallsNextWithModifiedRequestWillBeUsedForRouting()
     {
-        $app = $this->createAppWithoutFibersOrLogger(function (ServerRequestInterface $request, callable $next) {
+        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             return $next($request->withUri($request->getUri()->withPath('/users')));
         });
 
@@ -592,7 +592,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareCallsNextReturnsModifiedResponseWhenModifyingResponseFromRouter()
     {
-        $app = $this->createAppWithoutFibersOrLogger(function (ServerRequestInterface $request, callable $next) {
+        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             $response = $next($request);
             assert($response instanceof ResponseInterface);
 
@@ -623,7 +623,7 @@ class AppMiddlewareTest extends TestCase
 
     public function testGlobalMiddlewareReturnsResponseWithoutCallingNextReturnsResponseWithoutCallingRouter()
     {
-        $app = $this->createAppWithoutFibersOrLogger(function () {
+        $app = $this->createAppWithoutLogger(function () {
             return new Response(
                 200,
                 [
@@ -798,32 +798,6 @@ class AppMiddlewareTest extends TestCase
             $this->assertInstanceOf(AccessLogHandler::class, $next);
 
             array_unshift($handlers, $next, $first);
-        }
-
-        $first = array_shift($handlers);
-        $this->assertInstanceOf(AccessLogHandler::class, $first);
-
-        $ref->setValue($middleware, $handlers);
-
-        return $app;
-    }
-
-    /** @param callable|class-string ...$middleware */
-    private function createAppWithoutFibersOrLogger(...$middleware): App
-    {
-        $app = new App(...$middleware);
-
-        $ref = new \ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
-        $middleware = $ref->getValue($app);
-
-        $ref = new \ReflectionProperty($middleware, 'handlers');
-        $ref->setAccessible(true);
-        $handlers = $ref->getValue($middleware);
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
         }
 
         $first = array_shift($handlers);

--- a/tests/FiberHandlerTest.php
+++ b/tests/FiberHandlerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Framework\Tests;
+
+use FrameworkX\FiberHandler;
+use PHPUnit\Framework\TestCase;
+use React\EventLoop\Loop;
+use React\Http\Message\Response;
+use React\Http\Message\ServerRequest;
+use React\Promise\Deferred;
+use React\Promise\Promise;
+use React\Promise\PromiseInterface;
+use function React\Async\await;
+use function React\Promise\reject;
+use function React\Promise\resolve;
+
+class FiberHandlerTest extends TestCase
+{
+    public function setUp(): void
+    {
+        if (PHP_VERSION_ID < 80100 || !function_exists('React\Async\async')) {
+            $this->markTestSkipped('Requires PHP 8.1+ with react/async 4+');
+        }
+    }
+
+    public function testInvokeWithHandlerReturningResponseReturnsPromiseResolvingWithSameResponse()
+    {
+        $handler = new FiberHandler();
+
+        $request = new ServerRequest('GET', 'http://example.com/');
+        $response = new Response();
+
+        $promise = $handler($request, function () use ($response) { return $response; });
+
+        /** @var PromiseInterface $promise */
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+
+        $ret = null;
+        $promise->then(function ($value) use (&$ret) {
+            $ret = $value;
+        });
+
+        $this->assertSame($response, $ret);
+    }
+
+    public function testInvokeWithHandlerReturningPromiseResolvingWithResponseReturnsPromiseResolvingWithSameResponse()
+    {
+        $handler = new FiberHandler();
+
+        $request = new ServerRequest('GET', 'http://example.com/');
+        $response = new Response();
+
+        $promise = $handler($request, function () use ($response) { return resolve($response); });
+
+        /** @var PromiseInterface $promise */
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+
+        $ret = null;
+        $promise->then(function ($value) use (&$ret) {
+            $ret = $value;
+        });
+
+        $this->assertSame($response, $ret);
+    }
+
+    public function testInvokeWithHandlerReturningGeneratorReturningResponseReturnsPromiseResolvingWithSameResponse()
+    {
+        $handler = new FiberHandler();
+
+        $request = new ServerRequest('GET', 'http://example.com/');
+        $response = new Response();
+
+        $promise = $handler($request, function () use ($response) {
+            if (false) {
+                yield;
+            }
+            return $response;
+        });
+
+        /** @var PromiseInterface $promise */
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+
+        $ret = null;
+        $promise->then(function ($value) use (&$ret) {
+            $ret = $value;
+        });
+
+        $this->assertSame($response, $ret);
+    }
+
+    public function testInvokeWithHandlerReturningGeneratorReturningResponseAfterYieldingResolvedPromiseReturnsPromiseResolvingWithSameResponse()
+    {
+        $handler = new FiberHandler();
+
+        $request = new ServerRequest('GET', 'http://example.com/');
+        $response = new Response();
+
+        $promise = $handler($request, function () use ($response) {
+            return yield resolve($response);
+        });
+
+        /** @var PromiseInterface $promise */
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+
+        $ret = null;
+        $promise->then(function ($value) use (&$ret) {
+            $ret = $value;
+        });
+
+        $this->assertSame($response, $ret);
+    }
+
+    public function testInvokeWithHandlerReturningGeneratorReturningResponseAfterYieldingRejectedPromiseReturnsPromiseResolvingWithSameResponse()
+    {
+        $handler = new FiberHandler();
+
+        $request = new ServerRequest('GET', 'http://example.com/');
+        $response = new Response();
+
+        $promise = $handler($request, function () use ($response) {
+            try {
+                yield reject(new \RuntimeException('Foo'));
+            } catch (\RuntimeException $e) {
+                return $response;
+            }
+        });
+
+        /** @var PromiseInterface $promise */
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+
+        $ret = null;
+        $promise->then(function ($value) use (&$ret) {
+            $ret = $value;
+        });
+
+        $this->assertSame($response, $ret);
+    }
+
+    public function testInvokeWithHandlerReturningResponseAfterAwaitingResolvedPromiseReturnsPromiseResolvingWithSameResponse()
+    {
+        $handler = new FiberHandler();
+
+        $request = new ServerRequest('GET', 'http://example.com/');
+        $response = new Response();
+
+        $promise = $handler($request, function () use ($response) {
+            return await(resolve($response));
+        });
+
+        /** @var PromiseInterface $promise */
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+
+        $ret = null;
+        $promise->then(function ($value) use (&$ret) {
+            $ret = $value;
+        });
+
+        $this->assertSame($response, $ret);
+    }
+
+    public function testInvokeWithHandlerReturningResponseAfterAwaitingPendingPromiseReturnsPromiseResolvingWithSameResponse()
+    {
+        $handler = new FiberHandler();
+
+        $request = new ServerRequest('GET', 'http://example.com/');
+        $response = new Response();
+
+        $deferred = new Deferred();
+
+        $promise = $handler($request, function () use ($deferred) {
+            return await($deferred->promise());
+        });
+
+        /** @var PromiseInterface $promise */
+        $this->assertInstanceOf(PromiseInterface::class, $promise);
+
+        $ret = null;
+        $promise->then(function ($value) use (&$ret) {
+            $ret = $value;
+        });
+
+        $this->assertNull($ret);
+
+        $deferred->resolve($response);
+
+        // await next tick: https://github.com/reactphp/async/issues/27
+        await(new Promise(function ($resolve) {
+            Loop::futureTick($resolve);
+        }));
+
+        $this->assertSame($response, $ret);
+    }
+}

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -26,6 +26,10 @@ out=$(curl -v $base/ 2>&1 -X POST); match "HTTP/.* 405"
 out=$(curl -v $base/error 2>&1);        match "HTTP/.* 500" && match -iP "Content-Type: text/html; charset=utf-8[\r\n]" && match "<code>Unable to load error</code>"
 out=$(curl -v $base/error/null 2>&1);   match "HTTP/.* 500" && match -iP "Content-Type: text/html; charset=utf-8[\r\n]"
 
+out=$(curl -v $base/sleep/promise 2>&1);    match "HTTP/.* 200" && match -iP "Content-Type: text/plain; charset=utf-8[\r\n]"
+out=$(curl -v $base/sleep/coroutine 2>&1);  match "HTTP/.* 200" && match -iP "Content-Type: text/plain; charset=utf-8[\r\n]"
+out=$(curl -v $base/sleep/fiber 2>&1);      skipif "HTTP/.* 404" && match "HTTP/.* 200" && match -iP "Content-Type: text/plain; charset=utf-8[\r\n]" # skip PHP < 8.1
+
 out=$(curl -v $base/uri 2>&1);                          match "HTTP/.* 200" && match "$base/uri"
 out=$(curl -v $base/uri/ 2>&1);                         match "HTTP/.* 200" && match "$base/uri/"
 out=$(curl -v $base/uri/foo 2>&1);                      match "HTTP/.* 200" && match "$base/uri/foo"


### PR DESCRIPTION
This changeset ensures X automatically starts a new fiber for each request on PHP 8.1+. This means you can now simply use `await()` in your controller code without having to wrap anything in any explicit `async()` calls anymore. This makes building and consuming async APIs easier than ever before.

```php
$app->get('/book/{isbn}', function (Psr\Http\Message\ServerRequestInterface $request) use ($db) {
    $isbn = $request->getAttribute('isbn');
    $result = await($db->query(
        'SELECT title FROM book WHERE isbn = ?',
        [$isbn]
    ));

    assert($result instanceof React\MySQL\QueryResult);
    $data = $result->resultRows[0]['title'];

    return React\Http\Message\Response::plaintext(
        $data
    );
});
```

The first commit introduces a simple fiber implementation that works very similar to the `async()` function, but without introducing any external dependencies. The second commit optimizes this approach to only return a promise on demand internally.

Using fibers still shows a noticeable performance impact (~20% in my synthetic tests, but I invite more people to run their own benchmarks!), but there are still a number of outstanding optimizations that will improve this in the future. The optimization in the second commit already shows a ~35% performance improvement over using the simple `async()` implementation and there's definitely room for similar improvements in other areas. I've already filed https://github.com/reactphp/async/pull/30 upstream and will file more follow-up PRs once this is merged.

The test suite also employs a couple of workarounds that will no longer be needed once https://github.com/reactphp/async/issues/27 is addressed upstream. I've already prepared the required changes (talking 8+ hours of work here!) and will again file the PR once the above PR is merged.

Enjoy! 🚀

Builds on top of #116 and #62