### PR TITLE
Improve fiber tests to avoid now unneeded `await()` calls

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -877,11 +877,6 @@ class AppTest extends TestCase
             "OK\n"
         ));
 
-        // await next tick: https://github.com/reactphp/async/issues/27
-        await(new Promise(function ($resolve) {
-            Loop::futureTick($resolve);
-        }));
-
         /** @var ResponseInterface $response */
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
@@ -1151,11 +1146,6 @@ class AppTest extends TestCase
         $this->assertNull($response);
 
         $deferred->reject($exception);
-
-        // await next tick: https://github.com/reactphp/async/issues/27
-        await(new Promise(function ($resolve) {
-            Loop::futureTick($resolve);
-        }));
 
         /** @var ResponseInterface $response */
         $this->assertInstanceOf(ResponseInterface::class, $response);

--- a/tests/FiberHandlerTest.php
+++ b/tests/FiberHandlerTest.php
@@ -157,11 +157,6 @@ class FiberHandlerTest extends TestCase
 
         $deferred->resolve($response);
 
-        // await next tick: https://github.com/reactphp/async/issues/27
-        await(new Promise(function ($resolve) {
-            Loop::futureTick($resolve);
-        }));
-
         $this->assertSame($response, $ret);
     }
 }


### PR DESCRIPTION
This simple changeset improves the fiber tests introduced in (#117) to avoid now unneeded `await()` calls.

I'm marking this as WIP because it is currently expected to fail until https://github.com/reactphp/async/issues/27 is addressed upstream via https://github.com/reactphp/async/pull/32. I'll update this PR once this PR is released.