### PR TITLE
Add instructions for authorization header under Apache

### DIFF
--- a/docs/best-practices/deployment.md
+++ b/docs/best-practices/deployment.md
@@ -185,6 +185,9 @@ RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule .* index.php
+
+# This adds support for authorization header
+SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
 ```
 
 > ℹ️ **New to mod_rewrite?**

--- a/examples/apache/.htaccess
+++ b/examples/apache/.htaccess
@@ -3,3 +3,6 @@ RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule .* index.php
+
+# This adds support for authorization header
+SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0


### PR DESCRIPTION
This pull requests adds an additional line of configuration to the `.htaccess` file to support authorization headers under Apache.

I ran into this problem when I was setting up a new project which sets the HTTP `Authorization` header. It seems like Apache does not pass the `Authorization` header by default, because the default setting for the `CGIPassAuth` is `Off`, according to [Apache's documentation](https://httpd.apache.org/docs/2.4/en/mod/core.html#cgipassauth). The same issue has been reported in several forums e.g. [this one on stackoverflow](https://stackoverflow.com/questions/26475885/authorization-header-missing-in-php-post-request).

Adding these instructions to the `.htaccess` causes the authorization header to be passed along :+1: 

Inside our acceptance tests we're using the php docker image which has special configuration settings for Apache, thus sending the `Authorization` header along without any additional adjustments needed.