### PR TITLE
Improve error output for exception messages with special characters

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -191,6 +191,7 @@ $app->get('/error/null', function () {
 $app->get('/error/yield', function () {
     yield null;
 });
+$app->get('/error/class', 'Acme\Http\UnknownDeleteUserController');
 
 // OPTIONS *
 $app->options('', function () {

--- a/src/HtmlHandler.php
+++ b/src/HtmlHandler.php
@@ -24,7 +24,7 @@ body { display: grid; justify-content: center; align-items: center; grid-auto-ro
 h1 { margin: 0 .5em 0 0; border-right: calc(2 * max(0px, min(100vw - 700px + 1px, 1px))) solid #e3e4e7; padding-right: .5em; color: #aebdcc; font-size: 3em; }
 strong { color: #111827; font-size: 3em; }
 p { margin: .5em 0 0 0; grid-column: 2; color: #6b7280; }
-code { padding: 0 .3em; background-color: #f5f6f9; }
+code { padding: 0 .3em; background-color: #f5f6f9; } code span { padding: 0 .2em; border-radius: 3px; background-color: #0001; }
 a { color: inherit; }
 </style>
 </head>
@@ -50,13 +50,16 @@ HTML;
 
     public function escape(string $s): string
     {
-        return \addcslashes(
+        return \preg_replace_callback(
+            '/[\x00-\x1F]+/',
+            function (array $match): string {
+                return '<span>' . \addcslashes($match[0], "\x00..\xff") . '</span>';
+            },
             \preg_replace(
                 '/(^| ) |(?: $)/',
                 '$1&nbsp;',
                 \htmlspecialchars($s, \ENT_NOQUOTES | \ENT_SUBSTITUTE | \ENT_DISALLOWED, 'utf-8')
-            ),
-            "\0..\032\\"
+            )
         );
     }
 }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1329,27 +1329,27 @@ class AppTest extends TestCase
     {
         yield [
             InvalidConstructorPrivate::class,
-            'Cannot instantiate class ' . addslashes(InvalidConstructorPrivate::class)
+            'Cannot instantiate class ' . InvalidConstructorPrivate::class
         ];
 
         yield [
             InvalidConstructorProtected::class,
-            'Cannot instantiate class ' . addslashes(InvalidConstructorProtected::class)
+            'Cannot instantiate class ' . InvalidConstructorProtected::class
         ];
 
         yield [
             InvalidAbstract::class,
-            'Cannot instantiate abstract class ' . addslashes(InvalidAbstract::class)
+            'Cannot instantiate abstract class ' . InvalidAbstract::class
         ];
 
         yield [
             InvalidInterface::class,
-            'Cannot instantiate interface ' . addslashes(InvalidInterface::class)
+            'Cannot instantiate interface ' . InvalidInterface::class
         ];
 
         yield [
             InvalidTrait::class,
-            'Cannot instantiate trait ' . addslashes(InvalidTrait::class)
+            'Cannot instantiate trait ' . InvalidTrait::class
         ];
 
         yield [
@@ -1413,7 +1413,7 @@ class AppTest extends TestCase
 
         $this->assertStringContainsString("<title>Error 500: Internal Server Error</title>\n", (string) $response->getBody());
         $this->assertStringContainsString("<p>The requested page failed to load, please try again later.</p>\n", (string) $response->getBody());
-        $this->assertStringMatchesFormat("%a<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>BadMethodCallException</code> with message <code>Request handler class " . addslashes($class) . " failed to load: $error</code> in <code title=\"See %s\">Container.php:%d</code>.</p>\n%a", (string) $response->getBody());
+        $this->assertStringMatchesFormat("%a<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>BadMethodCallException</code> with message <code>Request handler class " . $class . " failed to load: $error</code> in <code title=\"See %s\">Container.php:%d</code>.</p>\n%a", (string) $response->getBody());
     }
 
     public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerClassRequiresUnexpectedCallableParameter()

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -407,15 +407,15 @@ class ErrorHandlerTest extends TestCase
             ],
             [
                 "new\n line",
-                'new\n line'
+                'new<span>\n</span> line'
             ],
             [
                 'sla/she\'s\\n',
-                'sla/she\'s\\\\n'
+                'sla/she\'s\\n'
             ],
             [
                 "hello\r\nworld",
-                'hello\r\nworld'
+                'hello<span>\r\n</span>world'
             ],
             [
                 '"with"<html>',

--- a/tests/HtmlHandlerTest.php
+++ b/tests/HtmlHandlerTest.php
@@ -44,15 +44,15 @@ class HtmlHandlerTest extends TestCase
             ],
             [
                 "hello\nworld",
-                'hello\nworld'
+                'hello<span>\n</span>world'
             ],
             [
                 "hello\tworld",
-                'hello\tworld'
+                'hello<span>\t</span>world'
             ],
             [
                 "hello\\nworld",
-                'hello\\\\nworld'
+                'hello\nworld'
             ],
             [
                 'h<e>llo',


### PR DESCRIPTION
This changeset improves error output for exception messages with special characters. In particular, fully qualified class names no longer have their backslash separator escaped with another backslash. Binary data and invalid UTF-8 will be replaced with a "�" (Unicode replacement character). Newlines in exception messages will be escaped like `\r\n` with a soft background color to discern this from the individual characters `\`+`r`+`\`+`n`.

Builds on top of #37