### PR TITLE
doc(testing): Fixed example for HelloControllerTest

### DIFF
--- a/docs/best-practices/testing.md
+++ b/docs/best-practices/testing.md
@@ -70,7 +70,7 @@ class HelloControllerTest extends TestCase
 {
     public function testControllerReturnsValidResponse()
     {
-        $request = new ServerRequest('http://example.com/');
+        $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new HelloController();
         $response = $controller($request);


### PR DESCRIPTION
The ServerRequest requires the HTTP Method as first parameter. This was missing in the example.