### PR TITLE
Add tests for `Dockerfile` instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,28 @@ jobs:
       - run: bash tests/await.sh
       - run: bash tests/acceptance.sh
 
+  Docker:
+    name: Docker (${{ matrix.dockerfile }})
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        dockerfile:
+          - "Dockerfile-basics"
+          - "Dockerfile-production"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+      - run: composer install -d tests/install-as-dep/
+      - run: docker build -f tests/${{ matrix.dockerfile }} tests/install-as-dep/
+      - run: docker run -d -p 8080:8080 -v "$PWD/examples/index.php":/app/public/index.php -v "$PWD/composer.json":/app/composer.json -v "$PWD/LICENSE":/app/LICENSE -v "$PWD/tests/":/app/tests/ $(docker images -q | head -n1)
+      - run: bash tests/await.sh
+      - run: bash tests/acceptance.sh
+      - run: docker stop $(docker ps -qn1)
+      - run: docker logs $(docker ps -qn1)
+        if: ${{ always() }}
+
   nginx-webserver:
     name: nginx + PHP-FPM (PHP ${{ matrix.php }})
     runs-on: ubuntu-20.04

--- a/tests/Dockerfile-basics
+++ b/tests/Dockerfile-basics
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+FROM php:8.1-cli
+
+WORKDIR /app/
+COPY public/ public/
+COPY vendor/ vendor/
+
+ENV X_LISTEN 0.0.0.0:8080
+EXPOSE 8080
+
+ENTRYPOINT php public/index.php

--- a/tests/Dockerfile-production
+++ b/tests/Dockerfile-production
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+FROM composer:2 AS build
+
+WORKDIR /app/
+COPY composer.json composer.lock ./
+# production environment should install optimized dependencies: 
+# RUN composer install --no-dev --ignore-platform-reqs --optimize-autoloader
+# dev environment already has dependencies installed:
+COPY vendor/ vendor/
+
+FROM php:8.1-alpine
+
+# recommended: install optional extensions ext-ev and ext-sockets
+RUN apk --no-cache add ${PHPIZE_DEPS} libev \ 
+    && pecl install ev \
+    && docker-php-ext-enable ev \
+    && docker-php-ext-install sockets \
+    && apk del ${PHPIZE_DEPS}
+
+WORKDIR /app/
+COPY public/ public/
+# COPY src/ src/
+COPY --from=build /app/vendor/ vendor/
+
+ENV X_LISTEN 0.0.0.0:8080
+EXPOSE 8080
+
+USER nobody:nobody
+ENTRYPOINT php public/index.php


### PR DESCRIPTION
This changeset adds some additional tests for the `Dockerfile` instructions recently added to our documentation. Special care is taken to ensure the `Dockerfile` instructions in the tests are very close to the documentation, so the CI setup contains a number of steps that wouldn't be needed otherwise. Ensuring the instructions are actually identical to the documentation (and stay so over time) is left up for a follow-up PR (PRs welcome!).

Builds on top of #136 and #148
Supersedes / closes #147 which uses a more complex approach to ensure the `Dockerfile` instructions are identical to the documentation (but somewhat artificial for the test suite)
Also done in preparation for signal handling as discussed in #144
Tests inspired by https://github.com/clue/reactphp-sqlite/pull/55 and others