### PR TITLE
Add signal handling support for `SIGINT` and `SIGTERM`

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -210,9 +210,13 @@ class App
         do {
             Loop::run();
 
-            // Fiber compatibility mode for PHP < 8.1: Restart loop as long as socket is available
-            $this->sapi->log('Warning: Loop restarted. Upgrade to react/async v4 recommended for production use.');
-        } while ($socket->getAddress() !== null);
+            if ($socket->getAddress() !== null) {
+                // Fiber compatibility mode for PHP < 8.1: Restart loop as long as socket is available
+                $this->sapi->log('Warning: Loop restarted. Upgrade to react/async v4 recommended for production use.');
+            } else {
+                break;
+            }
+        } while (true);
     }
 
     private function runOnce()


### PR DESCRIPTION
This changeset adds signal handling support for `SIGINT` and `SIGTERM`.

Updating the `Dockerfile` instructions to take advantage of this in Docker containers is left up for a follow-up PR once this PR and #149 are merged.

As discussed in #144
Refs #149 and #136