### PR TITLE
Update recommended `Dockerfile` instructions to run as PID 1

### DIFF
--- a/docs/best-practices/deployment.md
+++ b/docs/best-practices/deployment.md
@@ -524,7 +524,7 @@ be achieved by using a `Dockerfile` with the following contents:
     EXPOSE 8080
 
     USER nobody:nobody
-    ENTRYPOINT php public/index.php
+    ENTRYPOINT ["php", "public/index.php"]
     ```
 
 Simply place the `Dockerfile` in your project directory like this:

--- a/tests/Dockerfile-production
+++ b/tests/Dockerfile-production
@@ -26,4 +26,4 @@ ENV X_LISTEN 0.0.0.0:8080
 EXPOSE 8080
 
 USER nobody:nobody
-ENTRYPOINT php public/index.php
+ENTRYPOINT ["php", "public/index.php"]


### PR DESCRIPTION
This simple changeset updates the recommended `Dockerfile` instructions to run X as PID 1 without an implicit wrapping shell. In particular, by avoiding an additional `sh` process, we can ensure any signals sent always target the `php` process directly.

Note that PID 1 has special semantics on Unix-based systems. In particular, it does not have any default signal handling (which is why this builds on top of #150 first) and has additional responsibilities to reap zombie child processes. Child processes spawned directly using the ChildProcess component should be reaped just fine, but orphaned processes from deeper process trees may require special care. If in doubt, using a small init process like `tini` or `dump-init` inside your Docker container may be a good idea. In the long run, X should get additional features to handle the `SIGCHLD` signal to take care of any orphaned processes itself, but this is currently out of scope for this PR and should be addressed in a follow-up PR in the future.

Link dump for further details:
* https://www.kaggle.com/code/residentmario/best-practices-for-propagating-signals-on-docker/notebook
* https://docs.docker.com/engine/reference/run/#specify-an-init-process
* https://hynek.me/articles/docker-signals/
* https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html
* https://medium.com/@gchudnov/trapping-signals-in-docker-containers-7a57fdda7d86
* http://www.microhowto.info/howto/reap_zombie_processes_using_a_sigchld_handler.html

Builds on top of #136, #149 and #150