### PR TITLE
[WIP] Update workflow to reuse PHP versions matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,35 +5,8 @@ on:
   pull_request:
 
 jobs:
-  PHPUnit:
-    name: PHPUnit (PHP ${{ matrix.php }} on ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-20.04
-          - windows-2019
-        php:
-          - 8.1
-          - 8.0
-          - 7.4
-          - 7.3
-          - 7.2
-          - 7.1
-    steps:
-      - uses: actions/checkout@v2
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: xdebug
-      - run: composer install
-      - run: vendor/bin/phpunit --coverage-text --stderr
-        if: ${{ matrix.php >= 7.3 }}
-      - run: vendor/bin/phpunit --coverage-text --stderr -c phpunit.xml.legacy
-        if: ${{ matrix.php < 7.3 }}
-
-  Built-in-webserver:
-    name: Built-in webserver (PHP ${{ matrix.php }})
+  PHP-Matrix:
+    name: PHP ${{ matrix.php }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -44,11 +17,46 @@ jobs:
           - 7.3
           - 7.2
           - 7.1
+    outputs:
+      php: ${{ steps.version.outputs.version }}
+    steps:
+      - run: |
+          printf "PHP %s\r\n" ${{ matrix.php }}
+          printf "::set-output name=version::%s" ${{ matrix.php }}
+        id: version
+
+  PHPUnit:
+    name: PHPUnit (PHP ${{ matrix.php }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs:
+      - PHP-Matrix
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+          - windows-2019
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ needs.PHP-Matrix.outputs.php }}
+          coverage: xdebug
+      - run: composer install
+      - run: vendor/bin/phpunit --coverage-text --stderr
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text --stderr -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
+
+  Built-in-webserver:
+    name: Built-in webserver (PHP ${{ matrix.php }})
+    runs-on: ubuntu-20.04
+    needs:
+      - PHP-Matrix
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ needs.PHP-Matrix.outputs.php }}
       - run: composer install -d tests/install-as-dep/
       - run: php tests/install-as-dep/public/index.php &
       - run: bash tests/await.sh
@@ -79,15 +87,12 @@ jobs:
   nginx-webserver:
     name: nginx + PHP-FPM (PHP ${{ matrix.php }})
     runs-on: ubuntu-20.04
+    needs:
+      - PHP-Matrix
     strategy:
       matrix:
         php:
-          - 8.1
-          - 8.0
-          - 7.4
-          - 7.3
-          - 7.2
-          - 7.1
+          - ${{ needs.PHP-Matrix.outputs.php }}
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
@@ -102,15 +107,12 @@ jobs:
   Apache-webserver:
     name: Apache webserver (PHP ${{ matrix.php }})
     runs-on: ubuntu-20.04
+    needs:
+      - PHP-Matrix
     strategy:
       matrix:
         php:
-          - 8.1
-          - 8.0
-          - 7.4
-          - 7.3
-          - 7.2
-          - 7.1
+          - ${{ needs.PHP-Matrix.outputs.php }}
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
@@ -124,15 +126,12 @@ jobs:
   PHP-webserver:
     name: PHP webserver (PHP ${{ matrix.php }})
     runs-on: ubuntu-20.04
+    needs:
+      - PHP-Matrix
     strategy:
       matrix:
         php:
-          - 8.1
-          - 8.0
-          - 7.4
-          - 7.3
-          - 7.2
-          - 7.1
+          - ${{ needs.PHP-Matrix.outputs.php }}
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This WIP PR aims to update the workflow to reuse the supported PHP versions matrix. I've started working on this a couple of weeks ago but never quite got to finish this. At this point, it only serves to show the basic idea but doesn't actually run the full matrix anymore.

After spending some time on this, I'm currently leaning towards stopping work on this as its benefits are currently unclear. Even if it would allow us to reduce duplicate definitions in our workflow, it introduces some noticeable complexity to the definition and I'm not sure it's really worth it at this point.

As such, I'm only filing this to see if there's some interest and to get some feedback.