### PR TITLE
Update test suite to remove deprecated `utf8_decode()` in preparation for PHP 8.2

### DIFF
--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -426,7 +426,7 @@ class ErrorHandlerTest extends TestCase
                 "bin��������ary"
             ],
             [
-                utf8_decode("hellö!"),
+                "hell\xF6!",
                 "hell�!"
             ]
         ];

--- a/tests/HtmlHandlerTest.php
+++ b/tests/HtmlHandlerTest.php
@@ -59,7 +59,7 @@ class HtmlHandlerTest extends TestCase
                 'h&lt;e&gt;llo'
             ],
             [
-                utf8_decode('hellö.txt'),
+                "hell\xF6.txt",
                 'hell�.txt'
             ],
             [


### PR DESCRIPTION
The two methods `utf8_encode()` and `utf8_decode()` will be marked as deprecated in PHP 8.2, will raise a standard E_DEPRECATED diagnostic, and will be removed in PHP 9. The tests now use the string that would ultimately come from `utf8_decode()`, I don't expect that to change in the future due to the standardization of UTF8 and ISO 8859-1 (Latin-1).