### PR TITLE
Make `ErrorHandler` part of the public API

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -163,3 +163,58 @@ One of the main features of the `App` is middleware support.
 Middleware allows you to extract common functionality such as HTTP login, session handling or logging into reusable components.
 These middleware components can be added to both individual routes or globally to all registered routes.
 See [middleware documentation](middleware.md) for more details.
+
+## Error handling
+
+Each controller function needs to return a response object in order to send
+an HTTP response message. If the controller function throws an `Exception` (or
+`Throwable`) or returns any invalid type, the HTTP request will automatically be
+rejected with a `500 Internal Server Error` HTTP error response:
+
+```php
+<?php
+
+// …
+
+$app->get('/user', function () {
+    throw new BadMethodCallException();
+});
+```
+
+You can try out this example by sending an HTTP request like this:
+
+```bash hl_lines="2"
+$ curl -I http://localhost:8080/user
+HTTP/1.1 500 Internal Server Error
+…
+```
+
+Internally, the `App` will automatically add a default error handler by adding
+the [`ErrorHandler`](middleware.md#errorhandler) to the list of middleware used.
+You may also explicitly pass an [`ErrorHandler`](middleware.md#errorhandler)
+middleware to the `App` like this:
+
+```php title="public/index.php"
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$app = new FrameworkX\App(
+    new FrameworkX\ErrorHandler()
+);
+
+// Register routes here, see routing…
+
+$app->run();
+```
+
+> ⚠️ **Feature preview**
+>
+> Note that the [`ErrorHandler`](middleware.md#errorhandler) may currently only
+> be passed as a middleware instance and not as a middleware name to the `App`.
+
+By default, this error message contains only few details to the client to avoid
+leaking too much internal information.
+If you want to implement custom error handling, you're recommended to either
+catch any exceptions your own or use a custom [middleware handler](middleware.md)
+to catch any exceptions in your application.

--- a/docs/api/middleware.md
+++ b/docs/api/middleware.md
@@ -553,3 +553,18 @@ and also any requests that can not be routed.
 You can also combine global middleware handlers (think logging) with additional
 middleware handlers for individual routes (think authentication).
 Global middleware handlers will always be called before route middleware handlers.
+
+## Built-in middleware
+
+### ErrorHandler
+
+> ⚠️ **Feature preview**
+>
+> This is a feature preview, i.e. it might not have made it into the current beta.
+> Give feedback to help us prioritize.
+> We also welcome [contributors](../getting-started/community.md) to help out!
+
+X ships with a built-in `ErrorHandler` middleware that is responsible for handling
+errors and exceptions returned from following middleware and controllers.
+This default error handling can be configured through the [`App`](app.md).
+See [error handling](app.md#error-handling) for more details.

--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -553,10 +553,9 @@ int(42)
 ## Internal Server Error
 
 Each controller function needs to return a response object in order to send
-an HTTP response message.
-If the controller functions throws an `Exception` (or `Throwable`) or any other type, the
-HTTP request will automatically be rejected with a `500 Internal Server Error`
-HTTP error response:
+an HTTP response message. If the controller function throws an `Exception` (or
+`Throwable`) or returns any invalid type, the HTTP request will automatically be
+rejected with a `500 Internal Server Error` HTTP error response:
 
 ```php
 <?php
@@ -576,8 +575,5 @@ HTTP/1.1 500 Internal Server Error
 …
 ```
 
-This error message contains only few details to the client to avoid leaking
-internal information.
-If you want to implement custom error handling, you're recommended to either
-catch any exceptions your own or use a [middleware handler](middleware.md) to
-catch any exceptions in your application.
+This default error handling can be configured through the [`App`](app.md).
+See [error handling](app.md#error-handling) for more details.

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -8,7 +8,7 @@ use React\Http\Message\Response;
 use React\Promise\PromiseInterface;
 
 /**
- * @internal
+ * @final
  */
 class ErrorHandler
 {
@@ -27,6 +27,7 @@ class ErrorHandler
      *     method never throws or resolves a rejected promise. If the next
      *     handler fails to return a valid response, it will be turned into a
      *     valid error response before returning.
+     * @throws void
      */
     public function __invoke(ServerRequestInterface $request, callable $next)
     {
@@ -105,6 +106,7 @@ class ErrorHandler
         } while (true);
     } // @codeCoverageIgnore
 
+    /** @internal */
     public function requestNotFound(): ResponseInterface
     {
         return $this->htmlResponse(
@@ -114,6 +116,7 @@ class ErrorHandler
         );
     }
 
+    /** @internal */
     public function requestMethodNotAllowed(array $allowedMethods): ResponseInterface
     {
         $methods = \implode('/', \array_map(function (string $method) { return '<code>' . $method . '</code>'; }, $allowedMethods));
@@ -125,6 +128,7 @@ class ErrorHandler
         )->withHeader('Allow', \implode(', ', $allowedMethods));
     }
 
+    /** @internal */
     public function requestProxyUnsupported(): ResponseInterface
     {
         return $this->htmlResponse(
@@ -134,7 +138,7 @@ class ErrorHandler
         );
     }
 
-    public function errorInvalidException(\Throwable $e): ResponseInterface
+    private function errorInvalidException(\Throwable $e): ResponseInterface
     {
         $where = ' in ' . $this->where($e->getFile(), $e->getLine());
         $message = '<code>' . $this->html->escape($e->getMessage()) . '</code>';
@@ -147,7 +151,7 @@ class ErrorHandler
         );
     }
 
-    public function errorInvalidResponse($value): ResponseInterface
+    private function errorInvalidResponse($value): ResponseInterface
     {
         return $this->htmlResponse(
             Response::STATUS_INTERNAL_SERVER_ERROR,
@@ -157,7 +161,7 @@ class ErrorHandler
         );
     }
 
-    public function errorInvalidCoroutine($value, string $file, int $line): ResponseInterface
+    private function errorInvalidCoroutine($value, string $file, int $line): ResponseInterface
     {
         $where = ' near or before '. $this->where($file, $line) . '.';
 
@@ -184,7 +188,7 @@ class ErrorHandler
         );
     }
 
-    public function describeType($value): string
+    private function describeType($value): string
     {
         if ($value === null) {
             return 'null';

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -441,7 +441,11 @@ class ErrorHandlerTest extends TestCase
 
         $line = __LINE__ + 1;
         $e = new \RuntimeException($in);
-        $response = $handler->errorInvalidException($e);
+
+        // $response = $handler->errorInvalidException($e);
+        $ref = new \ReflectionMethod($handler, 'errorInvalidException');
+        $ref->setAccessible(true);
+        $response = $ref->invoke($handler, $e);
 
         $this->assertStringContainsString("<title>Error 500: Internal Server Error</title>\n", (string) $response->getBody());
         $this->assertStringContainsString("<p>The requested page failed to load, please try again later.</p>\n", (string) $response->getBody());
@@ -494,7 +498,10 @@ class ErrorHandlerTest extends TestCase
     {
         $handler = new ErrorHandler();
 
-        $response = $handler->errorInvalidResponse($value);
+        // $response = $handler->errorInvalidResponse($value);
+        $ref = new \ReflectionMethod($handler, 'errorInvalidResponse');
+        $ref->setAccessible(true);
+        $response = $ref->invoke($handler, $value);
 
         $this->assertStringContainsString("<title>Error 500: Internal Server Error</title>\n", (string) $response->getBody());
         $this->assertStringContainsString("<p>The requested page failed to load, please try again later.</p>\n", (string) $response->getBody());
@@ -511,7 +518,11 @@ class ErrorHandlerTest extends TestCase
 
         $file = __FILE__;
         $line = __LINE__;
-        $response = $handler->errorInvalidCoroutine($value, $file, $line);
+
+        // $response = $handler->errorInvalidCoroutine($value, $file, $line);
+        $ref = new \ReflectionMethod($handler, 'errorInvalidCoroutine');
+        $ref->setAccessible(true);
+        $response = $ref->invoke($handler, $value, $file, $line);
 
         $this->assertStringContainsString("<title>Error 500: Internal Server Error</title>\n", (string) $response->getBody());
         $this->assertStringContainsString("<p>The requested page failed to load, please try again later.</p>\n", (string) $response->getBody());


### PR DESCRIPTION
This changeset makes the existing `ErrorHandler` part of the public API. It can now be given explicitly to the `App` like this:

```php title="public/index.php"
<?php

require __DIR__ . '/../vendor/autoload.php';

$app = new FrameworkX\App(
    new FrameworkX\ErrorHandler()
);

// Register routes here, see routing…

$app->run();
```

This is a starting point to add more options to control error handling in follow-up PRs as discussed in #170.

Builds on top of #41, #39, #37, #12