### PR TITLE
Support loading `AccessLogHandler` and `ErrorHandler` from `Container`

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -280,28 +280,68 @@ adding the [`AccessLogHandler`](middleware.md#accessloghandler) to the list of
 middleware used. You may also explicitly pass an [`AccessLogHandler`](middleware.md#accessloghandler)
 middleware to the `App` like this:
 
-```php title="public/index.php"
-<?php
+=== "Using middleware instances"
 
-require __DIR__ . '/../vendor/autoload.php';
+    ```php title="public/index.php"
+    <?php
 
-$app = new FrameworkX\App(
-    new FrameworkX\AccessLogHandler(),
-    new FrameworkX\ErrorHandler()
-);
+    require __DIR__ . '/../vendor/autoload.php';
 
-// Register routes here, see routing…
+    $app = new FrameworkX\App(
+        new FrameworkX\AccessLogHandler(),
+        new FrameworkX\ErrorHandler()
+    );
 
-$app->run();
-```
+    // Register routes here, see routing…
+
+    $app->run();
+    ```
+
+=== "Using middleware names"
+
+    ```php title="public/index.php"
+    <?php
+
+    require __DIR__ . '/../vendor/autoload.php';
+
+    $app = new FrameworkX\App(
+        FrameworkX\AccessLogHandler::class,
+        FrameworkX\ErrorHandler::class
+    );
+
+    // Register routes here, see routing…
+
+    $app->run();
+    ```
 
 > ⚠️ **Feature preview**
 >
 > Note that the [`AccessLogHandler`](middleware.md#accessloghandler) may
-> currently only be passed as a global middleware instance and not as a global
-> middleware name to the `App` and may not be used for individual routes.
+> currently only be passed as a global middleware to the `App` and may not be
+> used for individual routes.
 
 If you pass an [`AccessLogHandler`](middleware.md#accessloghandler) to the `App`,
 it must be followed by an [`ErrorHandler`](middleware.md#errorhandler) like in
 the previous example. See also [error handling](#error-handling) for more
 details.
+
+If you do not explicitly pass an [`AccessLogHandler`](middleware.md#accessloghandler)
+to the `App`, a default access log handler will be added as a first handler automatically.
+You may use the [DI container configuration](../best-practices/controllers.md#container-configuration)
+to configure the default access log handler like this:
+
+```php title="public/index.php"
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$container = new FrameworkX\Container([
+    FrameworkX\AccessLogHandler::class => fn () => new FrameworkX\AccessLogHandler()
+]);
+
+$app = new FrameworkX\App($container);
+
+// Register routes here, see routing…
+
+$app->run();
+```

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -194,24 +194,59 @@ the [`ErrorHandler`](middleware.md#errorhandler) to the list of middleware used.
 You may also explicitly pass an [`ErrorHandler`](middleware.md#errorhandler)
 middleware to the `App` like this:
 
+=== "Using middleware instances"
+
+    ```php title="public/index.php"
+    <?php
+
+    require __DIR__ . '/../vendor/autoload.php';
+
+    $app = new FrameworkX\App(
+        new FrameworkX\ErrorHandler()
+    );
+
+    // Register routes here, see routing…
+
+    $app->run();
+    ```
+
+=== "Using middleware names"
+
+    ```php title="public/index.php"
+    <?php
+
+    require __DIR__ . '/../vendor/autoload.php';
+
+    $app = new FrameworkX\App(
+        FrameworkX\ErrorHandler::class
+    );
+
+    // Register routes here, see routing…
+
+    $app->run();
+    ```
+
+If you do not explicitly pass an [`ErrorHandler`](middleware.md#errorhandler) or
+if you pass another middleware before an [`ErrorHandler`](middleware.md#errorhandler)
+to the `App`, a default error handler will be added as a first handler automatically.
+You may use the [DI container configuration](../best-practices/controllers.md#container-configuration)
+to configure the default error handler like this:
+
 ```php title="public/index.php"
 <?php
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$app = new FrameworkX\App(
-    new FrameworkX\ErrorHandler()
-);
+$container = new FrameworkX\Container([
+    FrameworkX\ErrorHandler::class => fn () => new FrameworkX\ErrorHandler()
+]);
+
+$app = new FrameworkX\App($container);
 
 // Register routes here, see routing…
 
 $app->run();
 ```
-
-> ⚠️ **Feature preview**
->
-> Note that the [`ErrorHandler`](middleware.md#errorhandler) may currently only
-> be passed as a middleware instance and not as a middleware name to the `App`.
 
 By default, this error message contains only few details to the client to avoid
 leaking too much internal information.

--- a/src/Container.php
+++ b/src/Container.php
@@ -93,6 +93,19 @@ class Container
     }
 
     /** @internal */
+    public function getAccessLogHandler(): AccessLogHandler
+    {
+        if ($this->container instanceof ContainerInterface) {
+            if ($this->container->has(AccessLogHandler::class)) {
+                return $this->container->get(AccessLogHandler::class);
+            } else {
+                return new AccessLogHandler();
+            }
+        }
+        return $this->load(AccessLogHandler::class);
+    }
+
+    /** @internal */
     public function getErrorHandler(): ErrorHandler
     {
         if ($this->container instanceof ContainerInterface) {

--- a/src/Container.php
+++ b/src/Container.php
@@ -92,6 +92,19 @@ class Container
         };
     }
 
+    /** @internal */
+    public function getErrorHandler(): ErrorHandler
+    {
+        if ($this->container instanceof ContainerInterface) {
+            if ($this->container->has(ErrorHandler::class)) {
+                return $this->container->get(ErrorHandler::class);
+            } else {
+                return new ErrorHandler();
+            }
+        }
+        return $this->load(ErrorHandler::class);
+    }
+
     /**
      * @param class-string $name
      * @return object

--- a/src/RouteHandler.php
+++ b/src/RouteHandler.php
@@ -56,7 +56,7 @@ class RouteHandler
                 $container = $handler;
                 unset($handlers[$i]);
             } elseif ($handler instanceof AccessLogHandler || $handler === AccessLogHandler::class) {
-                throw new \TypeError('AccessLogHandler may currently only be passed as a global middleware instance');
+                throw new \TypeError('AccessLogHandler may currently only be passed as a global middleware');
             } elseif (!\is_callable($handler)) {
                 $handlers[$i] = $container->callable($handler);
             }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -178,11 +178,28 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
-    public function testConstructWithErrorHandlerClassThrows()
+    public function testConstructWithErrorHandlerClassOnlyAssignsErrorHandlerAfterDefaultAccessLogHandler()
     {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('ErrorHandler may currently only be passed as a middleware instance');
-        new App(ErrorHandler::class);
+        $app = new App(ErrorHandler::class);
+
+        $ref = new ReflectionProperty($app, 'handler');
+        $ref->setAccessible(true);
+        $handler = $ref->getValue($app);
+
+        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
+        $ref = new ReflectionProperty($handler, 'handlers');
+        $ref->setAccessible(true);
+        $handlers = $ref->getValue($handler);
+
+        if (PHP_VERSION_ID >= 80100) {
+            $first = array_shift($handlers);
+            $this->assertInstanceOf(FiberHandler::class, $first);
+        }
+
+        $this->assertCount(3, $handlers);
+        $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
+        $this->assertInstanceOf(ErrorHandler::class, $handlers[1]);
+        $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
     public function testConstructWithContainerAndErrorHandlerAssignsErrorHandlerAfterDefaultAccessLogHandler()
@@ -209,6 +226,101 @@ class AppTest extends TestCase
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
         $this->assertSame($errorHandler, $handlers[1]);
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
+    }
+
+    public function testConstructWithContainerAndErrorHandlerClassAssignsErrorHandlerFromContainerAfterDefaultAccessLogHandler()
+    {
+        $errorHandler = new ErrorHandler();
+
+        $container = $this->createMock(Container::class);
+        $container->expects($this->once())->method('getErrorHandler')->willReturn($errorHandler);
+
+        $app = new App($container, ErrorHandler::class);
+
+        $ref = new ReflectionProperty($app, 'handler');
+        $ref->setAccessible(true);
+        $handler = $ref->getValue($app);
+
+        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
+        $ref = new ReflectionProperty($handler, 'handlers');
+        $ref->setAccessible(true);
+        $handlers = $ref->getValue($handler);
+
+        if (PHP_VERSION_ID >= 80100) {
+            $first = array_shift($handlers);
+            $this->assertInstanceOf(FiberHandler::class, $first);
+        }
+
+        $this->assertCount(3, $handlers);
+        $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
+        $this->assertSame($errorHandler, $handlers[1]);
+        $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
+    }
+
+    public function testConstructWithMultipleContainersAndErrorHandlerClassAssignsErrorHandlerFromLastContainerBeforeErrorHandlerAfterDefaultAccessLogHandler()
+    {
+        $errorHandler = new ErrorHandler();
+
+        $unused = $this->createMock(Container::class);
+        $unused->expects($this->never())->method('getErrorHandler');
+
+        $container = $this->createMock(Container::class);
+        $container->expects($this->once())->method('getErrorHandler')->willReturn($errorHandler);
+
+        $app = new App($unused, $container, ErrorHandler::class, $unused);
+
+        $ref = new ReflectionProperty($app, 'handler');
+        $ref->setAccessible(true);
+        $handler = $ref->getValue($app);
+
+        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
+        $ref = new ReflectionProperty($handler, 'handlers');
+        $ref->setAccessible(true);
+        $handlers = $ref->getValue($handler);
+
+        if (PHP_VERSION_ID >= 80100) {
+            $first = array_shift($handlers);
+            $this->assertInstanceOf(FiberHandler::class, $first);
+        }
+
+        $this->assertCount(3, $handlers);
+        $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
+        $this->assertSame($errorHandler, $handlers[1]);
+        $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
+    }
+
+    public function testConstructWithMultipleContainersAndMiddlewareAssignsErrorHandlerFromLastContainerBeforeMiddlewareAfterDefaultAccessLogHandler()
+    {
+        $middleware = function (ServerRequestInterface $request, callable $next) { };
+        $errorHandler = new ErrorHandler();
+
+        $unused = $this->createMock(Container::class);
+        $unused->expects($this->never())->method('getErrorHandler');
+
+        $container = $this->createMock(Container::class);
+        $container->expects($this->once())->method('getErrorHandler')->willReturn($errorHandler);
+
+        $app = new App($unused, $container, $middleware, $unused);
+
+        $ref = new ReflectionProperty($app, 'handler');
+        $ref->setAccessible(true);
+        $handler = $ref->getValue($app);
+
+        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
+        $ref = new ReflectionProperty($handler, 'handlers');
+        $ref->setAccessible(true);
+        $handlers = $ref->getValue($handler);
+
+        if (PHP_VERSION_ID >= 80100) {
+            $first = array_shift($handlers);
+            $this->assertInstanceOf(FiberHandler::class, $first);
+        }
+
+        $this->assertCount(4, $handlers);
+        $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
+        $this->assertSame($errorHandler, $handlers[1]);
+        $this->assertSame($middleware, $handlers[2]);
+        $this->assertInstanceOf(RouteHandler::class, $handlers[3]);
     }
 
     public function testConstructWithMiddlewareAndErrorHandlerAssignsGivenErrorHandlerAfterMiddlewareAndDefaultAccessLogHandlerAndErrorHandlerFirst()
@@ -238,6 +350,45 @@ class AppTest extends TestCase
         $this->assertNotSame($errorHandler, $handlers[1]);
         $this->assertSame($middleware, $handlers[2]);
         $this->assertSame($errorHandler, $handlers[3]);
+        $this->assertInstanceOf(RouteHandler::class, $handlers[4]);
+    }
+
+    public function testConstructWithMultipleContainersAndMiddlewareAndErrorHandlerClassAssignsDefaultErrorHandlerFromLastContainerBeforeMiddlewareAndErrorHandlerFromLastContainerAfterDefaultAccessLogHandler()
+    {
+        $middleware = function (ServerRequestInterface $request, callable $next) { };
+
+        $unused = $this->createMock(Container::class);
+        $unused->expects($this->never())->method('getErrorHandler');
+
+        $errorHandler1 = new ErrorHandler();
+        $container1 = $this->createMock(Container::class);
+        $container1->expects($this->once())->method('getErrorHandler')->willReturn($errorHandler1);
+
+        $errorHandler2 = new ErrorHandler();
+        $container2 = $this->createMock(Container::class);
+        $container2->expects($this->once())->method('getErrorHandler')->willReturn($errorHandler2);
+
+        $app = new App($unused, $container1, $middleware, $container2, ErrorHandler::class, $unused);
+
+        $ref = new ReflectionProperty($app, 'handler');
+        $ref->setAccessible(true);
+        $handler = $ref->getValue($app);
+
+        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
+        $ref = new ReflectionProperty($handler, 'handlers');
+        $ref->setAccessible(true);
+        $handlers = $ref->getValue($handler);
+
+        if (PHP_VERSION_ID >= 80100) {
+            $first = array_shift($handlers);
+            $this->assertInstanceOf(FiberHandler::class, $first);
+        }
+
+        $this->assertCount(5, $handlers);
+        $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
+        $this->assertSame($errorHandler1, $handlers[1]);
+        $this->assertSame($middleware, $handlers[2]);
+        $this->assertSame($errorHandler2, $handlers[3]);
         $this->assertInstanceOf(RouteHandler::class, $handlers[4]);
     }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2,6 +2,7 @@
 
 namespace FrameworkX\Tests;
 
+use FrameworkX\AccessLogHandler;
 use FrameworkX\Container;
 use FrameworkX\ErrorHandler;
 use PHPUnit\Framework\TestCase;
@@ -381,6 +382,56 @@ class ContainerTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Request handler class FooBar failed to load: Unable to load class');
         $callable($request);
+    }
+
+    public function testGetAccessLogHandlerReturnsDefaultAccessLogHandlerInstance()
+    {
+        $container = new Container([]);
+
+        $accessLogHandler = $container->getAccessLogHandler();
+
+        $this->assertInstanceOf(AccessLogHandler::class, $accessLogHandler);
+    }
+
+    public function testGetAccessLogHandlerReturnsAccessLogHandlerInstanceFromMap()
+    {
+        $accessLogHandler = new AccessLogHandler();
+
+        $container = new Container([
+            AccessLogHandler::class => $accessLogHandler
+        ]);
+
+        $ret = $container->getAccessLogHandler();
+
+        $this->assertSame($accessLogHandler, $ret);
+    }
+
+    public function testGetAccessLogHandlerReturnsAccessLogHandlerInstanceFromPsrContainer()
+    {
+        $accessLogHandler = new AccessLogHandler();
+
+        $psr = $this->createMock(ContainerInterface::class);
+        $psr->expects($this->once())->method('has')->with(AccessLogHandler::class)->willReturn(true);
+        $psr->expects($this->once())->method('get')->with(AccessLogHandler::class)->willReturn($accessLogHandler);
+
+        $container = new Container($psr);
+
+        $ret = $container->getAccessLogHandler();
+
+        $this->assertSame($accessLogHandler, $ret);
+    }
+
+    public function testGetAccessLogHandlerReturnsDefaultAccessLogHandlerInstanceIfPsrContainerHasNoEntry()
+    {
+        $psr = $this->createMock(ContainerInterface::class);
+        $psr->expects($this->once())->method('has')->with(AccessLogHandler::class)->willReturn(false);
+        $psr->expects($this->never())->method('get');
+
+        $container = new Container($psr);
+
+        $accessLogHandler = $container->getAccessLogHandler();
+
+        $this->assertInstanceOf(AccessLogHandler::class, $accessLogHandler);
     }
 
     public function testGetErrorHandlerReturnsDefaultErrorHandlerInstance()


### PR DESCRIPTION
This changeset adds support for loading the `AccessLogHandler` and `ErrorHandler` from the `Container`. They can now be given explicitly to the `App` like this:

```php title="public/index.php"
<?php

require __DIR__ . '/../vendor/autoload.php';

$app = new FrameworkX\App(
    FrameworkX\AccessLogHandler::class,
    FrameworkX\ErrorHandler::class
);

// Register routes here, see routing…

$app->run();
```

On top of this, you may now configure the default handlers with an explicit DI container configuration like this:

```php
<?php

require __DIR__ . '/../vendor/autoload.php';

$container = new FrameworkX\Container([
    FrameworkX\AccessLogHandler::class => fn () => new FrameworkX\AccessLogHandler(),
    FrameworkX\ErrorHandler::class => fn () => new FrameworkX\ErrorHandler()
]);

$app = new FrameworkX\App($container);

// Register routes here, see routing…

$app->run();
```

This is the next step in adding more options to control access logging and error handling in follow-up PRs as discussed in #169 and #170.

Builds on top of #173 and #174