### PR TITLE
Support string variables in container configuration for factory functions

### DIFF
--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -209,7 +209,7 @@ the dependency injection container like this:
     require __DIR__ . '/../vendor/autoload.php';
 
     $container = new FrameworkX\Container([
-        Acme\Todo\HelloController::class => fn() => new Acme\Todo\HelloController();
+        Acme\Todo\HelloController::class => fn() => new Acme\Todo\HelloController()
     ]);
 
 
@@ -283,6 +283,36 @@ $container = new FrameworkX\Container([
 
 // …
 ```
+
+Factory functions used in the container configuration map may also reference
+string variables defined in the container configuration. This can be
+particularly useful when combining autowiring with some manual configuration
+like this:
+
+```php title="public/index.php"
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$container = new FrameworkX\Container([
+    Acme\Todo\UserController::class => function (string $name) {
+        // example UserController class requires single string argument
+        return new Acme\Todo\UserController($name);
+    },
+    'name' => 'Acme'
+]);
+
+// …
+```
+
+> ℹ️ **Avoiding name conflicts**
+>
+> Note that class names and string variables share the same container
+> configuration map and as such might be subject to name collisions as a single
+> entry may only have a single value. For this reason, container variables will
+> only be used for container functions by default. We highly recommend using
+> namespaced class names like in the previous example. You may also want to make
+> sure that container variables use unique names prefixed with your vendor name.
 
 The container configuration may also be used to map a class name to a different
 class name that implements the same interface, either by mapping between two

--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -285,9 +285,9 @@ $container = new FrameworkX\Container([
 ```
 
 Factory functions used in the container configuration map may also reference
-string variables defined in the container configuration. This can be
-particularly useful when combining autowiring with some manual configuration
-like this:
+string variables defined in the container configuration. You may also use
+factory functions that return string variables. This can be particularly useful
+when combining autowiring with some manual configuration like this:
 
 ```php title="public/index.php"
 <?php
@@ -295,11 +295,12 @@ like this:
 require __DIR__ . '/../vendor/autoload.php';
 
 $container = new FrameworkX\Container([
-    Acme\Todo\UserController::class => function (string $name) {
-        // example UserController class requires single string argument
-        return new Acme\Todo\UserController($name);
+    Acme\Todo\UserController::class => function (string $name, string $hostname) {
+        // example UserController class requires two string arguments
+        return new Acme\Todo\UserController($name, $hostname);
     },
-    'name' => 'Acme'
+    'name' => 'Acme',
+    'hostname' => fn(): string => gethostname()
 ]);
 
 // …

--- a/src/Container.php
+++ b/src/Container.php
@@ -127,7 +127,12 @@ class Container
                     throw new \BadMethodCallException('Factory for ' . $name . ' is recursive');
                 }
 
-                $this->container[$name] = $this->load($this->container[$name], $depth - 1);
+                $value = $this->load($this->container[$name], $depth - 1);
+                if (!$value instanceof $name) {
+                    throw new \BadMethodCallException('Factory for ' . $name . ' returned unexpected ' . (is_object($value) ? get_class($value) : gettype($value)));
+                }
+
+                $this->container[$name] = $value;
             } elseif ($this->container[$name] instanceof \Closure) {
                 // build list of factory parameters based on parameter types
                 $closure = new \ReflectionFunction($this->container[$name]);
@@ -142,7 +147,8 @@ class Container
                     }
 
                     $value = $this->load($value, $depth - 1);
-                } elseif (!$value instanceof $name) {
+                }
+                if (!$value instanceof $name) {
                     throw new \BadMethodCallException('Factory for ' . $name . ' returned unexpected ' . (is_object($value) ? get_class($value) : gettype($value)));
                 }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -280,6 +280,36 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
+    public function testCallableReturnsCallableThatThrowsWhenMapReferencesClassNameThatDoesNotMatchType()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $container = new Container([
+            \stdClass::class => Response::class
+        ]);
+
+        $callable = $container->callable(\stdClass::class);
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Factory for stdClass returned unexpected React\Http\Message\Response');
+        $callable($request);
+    }
+
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReturnsClassNameThatDoesNotMatchType()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $container = new Container([
+            \stdClass::class => function () { return Response::class; }
+        ]);
+
+        $callable = $container->callable(\stdClass::class);
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Factory for stdClass returned unexpected React\Http\Message\Response');
+        $callable($request);
+    }
+
     public function testCallableReturnsCallableThatThrowsWhenFactoryRequiresInvalidClassName()
     {
         $request = new ServerRequest('GET', 'http://example.com/');

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -340,6 +340,23 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
+    public function testCallableReturnsCallableThatThrowsWhenFactoryIsRecursiveClassName()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $container = new Container([
+            \stdClass::class => function (): string {
+                return \stdClass::class;
+            }
+        ]);
+
+        $callable = $container->callable(\stdClass::class);
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Factory for stdClass is recursive');
+        $callable($request);
+    }
+
     public function testCallableReturnsCallableForClassNameViaPsrContainer()
     {
         $request = new ServerRequest('GET', 'http://example.com/');


### PR DESCRIPTION
This changeset adds support for string variables in the container configuration for all factory functions:

```php title="public/index.php"
<?php

require __DIR__ . '/../vendor/autoload.php';

$container = new FrameworkX\Container([
    Acme\Todo\UserController::class => function (string $name, string $hostname) {
        // example UserController class requires two string arguments
        return new Acme\Todo\UserController($name, $hostname);
    },
    'name' => 'Acme',
    'hostname' => fn(): string => gethostname()
]);

// …
```

This is a first step in adding support for environment variables and `.env` (dotenv) files as discussed in #101.

Builds on top of #163, #97, #95 and others