### PR TITLE
Support scalar container variables for factory functions

### DIFF
--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -285,8 +285,8 @@ $container = new FrameworkX\Container([
 ```
 
 Factory functions used in the container configuration map may also reference
-string variables defined in the container configuration. You may also use
-factory functions that return string variables. This can be particularly useful
+scalar variables defined in the container configuration. You may also use
+factory functions that return scalar variables. This can be particularly useful
 when combining autowiring with some manual configuration like this:
 
 ```php title="public/index.php"
@@ -295,11 +295,11 @@ when combining autowiring with some manual configuration like this:
 require __DIR__ . '/../vendor/autoload.php';
 
 $container = new FrameworkX\Container([
-    Acme\Todo\UserController::class => function (string $name, string $hostname) {
-        // example UserController class requires two string arguments
-        return new Acme\Todo\UserController($name, $hostname);
+    Acme\Todo\UserController::class => function (bool $debug, string $hostname) {
+        // example UserController class requires two scalar arguments
+        return new Acme\Todo\UserController($debug, $hostname);
     },
-    'name' => 'Acme',
+    'debug' => false,
     'hostname' => fn(): string => gethostname()
 ]);
 
@@ -308,7 +308,7 @@ $container = new FrameworkX\Container([
 
 > ℹ️ **Avoiding name conflicts**
 >
-> Note that class names and string variables share the same container
+> Note that class names and scalar variables share the same container
 > configuration map and as such might be subject to name collisions as a single
 > entry may only have a single value. For this reason, container variables will
 > only be used for container functions by default. We highly recommend using


### PR DESCRIPTION
This changeset adds support for scalar variables in the container configuration for all factory functions:

```php title="public/index.php"
<?php

require __DIR__ . '/../vendor/autoload.php';

$container = new FrameworkX\Container([
    Acme\Todo\UserController::class => function (bool $debug, string $hostname) {
        // example UserController class requires two scalar arguments
        return new Acme\Todo\UserController($debug, $hostname);
    },
    'debug' => false,
    'hostname' => fn(): string => gethostname()
]);

// …
```

The previous version only supported `string` values, we now support all `scalar` values (`string`, `int`, `float`, `bool`). This is the next step in adding better configuration support and support for environment variables and `.env` (dotenv) files as discussed in #101.

Builds on top of #178, #163, #97, #95 and others