### PR TITLE
Support explicit container configuration for factory functions with nullable arguments and defaults values

### DIFF
--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -188,7 +188,8 @@ covers most common use cases:
 * Class names need to be loadable through the autoloader. See
   [composer autoloading](#composer-autoloading) above.
 * Each class may or may not have a constructor.
-* If the constructor has an optional argument, it will be omitted.
+* If the constructor has an optional argument, it will be omitted unless an
+  explicit [container configuration](#container-configuration) is used.
 * If the constructor has a nullable argument, it will be given a `null` value
   unless an explicit [container configuration](#container-configuration) is used.
 * If the constructor references another class, it will load this class next.
@@ -306,6 +307,25 @@ manual configuration like this:
         'debug' => false,
         'hostname' => fn(): string => gethostname()
     ]);
+
+    // …
+    ```
+
+=== "Default values"
+
+    ```php title="public/index.php"
+    <?php
+
+    require __DIR__ . '/../vendor/autoload.php';
+
+    $container = new FrameworkX\Container([
+        Acme\Todo\UserController::class => function (bool $debug = false) {
+            // example UserController class uses $debug, apply default if not set
+            return new Acme\Todo\UserController($debug);
+        },
+        'debug' => true
+    ]);
+
 
     // …
     ```

--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -189,7 +189,8 @@ covers most common use cases:
   [composer autoloading](#composer-autoloading) above.
 * Each class may or may not have a constructor.
 * If the constructor has an optional argument, it will be omitted.
-* If the constructor has a nullable argument, it will be given a `null` value.
+* If the constructor has a nullable argument, it will be given a `null` value
+  unless an explicit [container configuration](#container-configuration) is used.
 * If the constructor references another class, it will load this class next.
 
 This covers most common use cases where the request handler class uses a
@@ -290,22 +291,43 @@ scalar value for container variables or factory functions that return any such
 value. This can be particularly useful when combining autowiring with some
 manual configuration like this:
 
-```php title="public/index.php"
-<?php
+=== "Scalar values"
 
-require __DIR__ . '/../vendor/autoload.php';
+    ```php title="public/index.php"
+    <?php
 
-$container = new FrameworkX\Container([
-    Acme\Todo\UserController::class => function (bool $debug, string $hostname) {
-        // example UserController class uses two container variables
-        return new Acme\Todo\UserController($debug, $hostname);
-    },
-    'debug' => false,
-    'hostname' => fn(): string => gethostname()
-]);
+    require __DIR__ . '/../vendor/autoload.php';
 
-// …
-```
+    $container = new FrameworkX\Container([
+        Acme\Todo\UserController::class => function (bool $debug, string $hostname) {
+            // example UserController class uses two container variables
+            return new Acme\Todo\UserController($debug, $hostname);
+        },
+        'debug' => false,
+        'hostname' => fn(): string => gethostname()
+    ]);
+
+    // …
+    ```
+
+=== "Nullable values"
+
+    ```php title="public/index.php"
+    <?php
+
+    require __DIR__ . '/../vendor/autoload.php';
+
+    $container = new FrameworkX\Container([
+        Acme\Todo\UserController::class => function (?string $name) {
+            // example UserController class uses $name, defaults to null if not set
+            return new Acme\Todo\UserController($name ?? 'ACME');
+        },
+        'name' => 'Demo'
+    ]);
+
+
+    // …
+    ```
 
 > ℹ️ **Avoiding name collisions**
 >

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -67,6 +67,95 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
+    public function testCallableReturnsCallableForNullableClassViaAutowiringWillDefaultToNullValue()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $controller = new class(new \stdClass()) {
+            private $data;
+
+            public function __construct(?\stdClass $data)
+            {
+                $this->data = $data;
+            }
+
+            public function __invoke(ServerRequestInterface $request)
+            {
+                return new Response(200, [], json_encode($this->data));
+            }
+        };
+
+        $container = new Container([]);
+
+        $callable = $container->callable(get_class($controller));
+        $this->assertInstanceOf(\Closure::class, $callable);
+
+        $response = $callable($request);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('null', (string) $response->getBody());
+    }
+
+    public function testCallableReturnsCallableForNullableClassViaContainerConfiguration()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $controller = new class(new \stdClass()) {
+            private $data;
+
+            public function __construct(?\stdClass $data)
+            {
+                $this->data = $data;
+            }
+
+            public function __invoke(ServerRequestInterface $request)
+            {
+                return new Response(200, [], json_encode($this->data));
+            }
+        };
+
+        $container = new Container([
+            \stdClass::class => (object) []
+        ]);
+
+        $callable = $container->callable(get_class($controller));
+        $this->assertInstanceOf(\Closure::class, $callable);
+
+        $response = $callable($request);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('{}', (string) $response->getBody());
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testCallableReturnsCallableForUnionWithNullViaAutowiringWillDefaultToNullValue()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $controller = new class(null) {
+            private $data = false;
+
+            #[PHP8] public function __construct(string|int|null $data) { $this->data = $data; }
+
+            public function __invoke(ServerRequestInterface $request)
+            {
+                return new Response(200, [], json_encode($this->data));
+            }
+        };
+
+        $container = new Container([]);
+
+        $callable = $container->callable(get_class($controller));
+        $this->assertInstanceOf(\Closure::class, $callable);
+
+        $response = $callable($request);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('null', (string) $response->getBody());
+    }
+
     public function testCallableReturnsCallableForClassNameViaAutowiringWithFactoryFunctionForDependency()
     {
         $request = new ServerRequest('GET', 'http://example.com/');
@@ -310,6 +399,76 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableContainerVariables()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $controller = new class(new Response()) {
+            private $response;
+
+            public function __construct(ResponseInterface $response)
+            {
+                $this->response = $response;
+            }
+
+            public function __invoke()
+            {
+                return $this->response;
+            }
+        };
+
+        $container = new Container([
+            ResponseInterface::class => function (?\stdClass $user, ?\stdClass $data) {
+                return new Response(200, [], json_encode(['user' => $user, 'data' => $data]));
+            },
+            'user' => (object) []
+        ]);
+
+        $callable = $container->callable(get_class($controller));
+        $this->assertInstanceOf(\Closure::class, $callable);
+
+        $response = $callable($request);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('{"user":{},"data":null}', (string) $response->getBody());
+    }
+
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableContainerVariablesWithFactory()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $controller = new class(new Response()) {
+            private $response;
+
+            public function __construct(ResponseInterface $response)
+            {
+                $this->response = $response;
+            }
+
+            public function __invoke()
+            {
+                return $this->response;
+            }
+        };
+
+        $container = new Container([
+            ResponseInterface::class => function (?\stdClass $user, ?\stdClass $data) {
+                return new Response(200, [], json_encode(['user' => $user, 'data' => $data]));
+            },
+            'user' => function (): ?\stdClass {
+                return (object) [];
+            }
+        ]);
+
+        $callable = $container->callable(get_class($controller));
+        $this->assertInstanceOf(\Closure::class, $callable);
+
+        $response = $callable($request);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('{"user":{},"data":null}', (string) $response->getBody());
+    }
+
     public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresScalarVariables()
     {
         $request = new ServerRequest('GET', 'http://example.com/');
@@ -446,7 +605,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(get_class($controller));
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Container variable $username is not defined');
+        $this->expectExceptionMessage('Argument 1 ($username) of {closure}() is not defined');
         $callable($request);
     }
 
@@ -716,6 +875,35 @@ class ContainerTest extends TestCase
             private $data;
 
             public function __construct(\stdClass $data)
+            {
+                $this->data = $data;
+            }
+
+            public function __invoke(ServerRequestInterface $request)
+            {
+                return new Response(200, [], json_encode($this->data));
+            }
+        };
+
+        $container = new Container([
+            \stdClass::class => 'Yes'
+        ]);
+
+        $callable = $container->callable(get_class($controller));
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Class Yes not found');
+        $callable($request);
+    }
+
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesNullableClassButGetsStringVariable()
+    {
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $controller = new class(new \stdClass()) {
+            private $data;
+
+            public function __construct(?\stdClass $data)
             {
                 $this->data = $data;
             }


### PR DESCRIPTION
This changeset adds support for optional values in container configuration and support for nullable arguments and default values in factory functions:

```php title="public/index.php"
<?php

require __DIR__ . '/../vendor/autoload.php';

$container = new FrameworkX\Container([
    Acme\Todo\UserController::class => function (bool $debug = false) {
        // example UserController class uses $debug, apply default if not set
        return new Acme\Todo\UserController($debug);
    },
    'debug' => true
]);

// …
```

```php title="public/index.php"
<?php

require __DIR__ . '/../vendor/autoload.php';

$container = new FrameworkX\Container([
    Acme\Todo\UserController::class => function (?string $name) {
        // example UserController class uses $name, defaults to null if not set
        return new Acme\Todo\UserController($name ?? 'ACME');
    },
    'name' => 'Demo'
]);

// …
```

The previous version would always omit parameters with default values and nullable values without checking if an explicit container variable is set. We now first check to see if an explicit container variable is set and use this value if available. If this value is not available, we continue using the default value or a `null` value. This is the next step in adding better configuration support and support for (optional) environment variables and `.env` (dotenv) files as discussed in #101.

Builds on top of #180, #179, #178, #163, #97, #95 and others