### PR TITLE
Support `null` values in container variables for factory functions

### DIFF
--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -288,9 +288,9 @@ $container = new FrameworkX\Container([
 
 Factory functions used in the container configuration map may also reference
 variables defined in the container configuration. You may use any object or
-scalar value for container variables or factory functions that return any such
-value. This can be particularly useful when combining autowiring with some
-manual configuration like this:
+scalar or `null` value for container variables or factory functions that return
+any such value. This can be particularly useful when combining autowiring with
+some manual configuration like this:
 
 === "Scalar values"
 


### PR DESCRIPTION
This changeset adds support for `null` values in container configuration that are used in factory functions:

```php title="public/index.php"
<?php

require __DIR__ . '/../vendor/autoload.php';

$container = new FrameworkX\Container([
    Acme\Todo\UserController::class => function (?string $name) {
        // example UserController class uses $name as string or null
        return new Acme\Todo\UserController($name);
    },
    'name' => fn(): ?string => $_ENV['APP_NAME'] ?? null
]);

// …
```

The previous version only supported `object` and `scalar` values, we now also support `null` values. #181 already added support for passing `null` values for nullable arguments that are not set at all, this changeset now also includes support for explicit `null` values in the configuration. This is the next step in adding better configuration support and support for environment variables and `.env` (dotenv) files as discussed in #101.

Builds on top of #182, #181, #180, #179, #178, #163, #97, #95 and others