### PR TITLE
Allow auto-wiring container-parameters without using factory-callback

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -206,7 +206,7 @@ class Container
 
         // build list of constructor parameters based on parameter types
         $ctor = $class->getConstructor();
-        $params = $ctor === null ? [] : $this->loadFunctionParams($ctor, $depth, false);
+        $params = $ctor === null ? [] : $this->loadFunctionParams($ctor, $depth, true);
 
         // instantiate with list of parameters
         return $this->container[$name] = $params === [] ? new $name() : $class->newInstance(...$params);


### PR DESCRIPTION
Imagine you wanted to have a service with a constructor parameter of a string like this:

```php
class UserController
{
    public function __construct(string $hostname)
    {
        // ...
    }
}
```

Prior to this change, you would have to do this.

```php
$container = new FrameworkX\Container([
    UserController::class => function (string $hostname): UserController {
        return new UserController($hostname);
    },
    'hostname' => 'Some string value',
]);
```

After this change, you can do this:

```php
$container = new FrameworkX\Container([
    'hostname' => 'Some string value',
]);
```

I am still relatively new to this framework, so I don't know whether this will break some anything.