### PR TITLE
Respect explicit response status code when `Location` response header is given (PHP SAPI)

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -200,4 +200,10 @@ $app->options('', function () {
     return new React\Http\Message\Response(200);
 });
 
+$app->get('/location/{status:\d+}', function (Psr\Http\Message\ServerRequestInterface $request) {
+    $statusCode = (int) $request->getAttribute('status');
+
+    return new React\Http\Message\Response($statusCode, ['Location' => '/foobar']);
+});
+
 $app->run();

--- a/src/Io/SapiHandler.php
+++ b/src/Io/SapiHandler.php
@@ -86,8 +86,6 @@ class SapiHandler
         $status = $response->getStatusCode();
         $body = $response->getBody();
 
-        header($_SERVER['SERVER_PROTOCOL'] . ' ' . $status . ' ' . $response->getReasonPhrase());
-
         if ($status === Response::STATUS_NO_CONTENT) {
             // `204 No Content` MUST NOT include "Content-Length" response header
             $response = $response->withoutHeader('Content-Length');
@@ -111,6 +109,8 @@ class SapiHandler
             }
         }
         ini_set('default_charset', $old);
+
+        header($_SERVER['SERVER_PROTOCOL'] . ' ' . $status . ' ' . $response->getReasonPhrase());
 
         if (($_SERVER['REQUEST_METHOD'] ?? '') === 'HEAD' || $status === Response::STATUS_NO_CONTENT || $status === Response::STATUS_NOT_MODIFIED) {
             $body->close();

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -75,7 +75,7 @@ out=$(curl -v $base/users/a+b 2>&1);                    match "HTTP/.* 200" && m
 out=$(curl -v $base/users/Wham! 2>&1);                  match "HTTP/.* 200" && match "Hello Wham!!"
 out=$(curl -v $base/users/Wham%21 2>&1);                match "HTTP/.* 200" && match "Hello Wham!!"
 out=$(curl -v $base/users/AC%2FDC 2>&1);                skipif "HTTP/.* 404"    && match "HTTP/.* 200" && match "Hello AC/DC!" # skip Apache (404 unless `AllowEncodedSlashes NoDecode`)
-out=$(curl -v $base/users/bi%00n 2>&1);                 skipif "HTTP/.* 40[04]" && match "HTTP/.* 200" && match "Hello bi�n!" # skip nginx (400) and Apache (404) 
+out=$(curl -v $base/users/bi%00n 2>&1);                 skipif "HTTP/.* 40[04]" && match "HTTP/.* 200" && match "Hello bi�n!" # skip nginx (400) and Apache (404)
 
 out=$(curl -v $base/users 2>&1);     match "HTTP/.* 404"
 out=$(curl -v $base/users/ 2>&1);    match "HTTP/.* 404"
@@ -125,5 +125,10 @@ out=$(curl -v $base/headers -H 'V: a' -H 'V: b' 2>&1);      skipif "Server: ngin
 
 out=$(curl -v --proxy $baseWithPort $base/debug 2>&1);      skipif "Server: nginx" && match "HTTP/.* 400" # skip nginx (continues like direct request)
 out=$(curl -v --proxy $baseWithPort -p $base/debug 2>&1);   skipif "CONNECT aborted" && match "HTTP/.* 400" # skip PHP development server (rejects as "Malformed HTTP request")
+
+out=$(curl -v $base/location/201 2>&1);   match "HTTP/.* 201" && match "Location: /foobar"
+out=$(curl -v $base/location/202 2>&1);   match "HTTP/.* 202" && match "Location: /foobar"
+out=$(curl -v $base/location/301 2>&1);   match "HTTP/.* 301" && match "Location: /foobar"
+out=$(curl -v $base/location/302 2>&1);   match "HTTP/.* 302" && match "Location: /foobar"
 
 echo "OK ($n)"


### PR DESCRIPTION
## Let's say, this is your code:

```php
$app->get('/foo', function () {
    return new \React\Http\Message\Response(202, [
        'Location' => '/bar',
    ]);
});
```

- When you use ReactPHP as webserver, the status code will be 202 (as expected).
- When you use PHP's built-in webserver, the status code will be 302 (unexpected).

## So, why does this happen?

When you use `header(...)` to set the `Location` header, PHP will update the status code to 302. This behavior is even mentioned in the official documentation: [PHP: header - Manual](https://www.php.net/manual/en/function.header.php)

```
The second special case is the "Location:" header. Not only does it send this header back to the browser, but it also returns a REDIRECT (302) status code to the browser unless the 201 or a 3xx status code has already been set.
```

Here is the corresponding code in `php/php-src`: https://github.com/php/php-src/blob/php-8.1.11/main/SAPI.c#L806-L821

## Should this happen?

I think, this behavior is more confusing than it is helpful. It should not be the decision of PHP to override my status code. According to [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2), the `Location` header has a defined behavior for the status codes 201 and 3xx.

But that is not an exclusive definition. Any HTTP response may contain a `Location` header, but the expected behavior is not defined by this RFC. That means, it can be used by a proprietary API definition for other status codes.

## What does this change do?

The status code is now set **after** setting all other headers. This will override any status code that has priorly been set by PHP. So now my choice of status code is respected.