### PR TITLE
Allow Streaming Request

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -12,6 +12,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\HttpServer;
 use React\Http\Message\Response;
+use React\Http\Middleware\StreamingRequestMiddleware;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use React\Socket\SocketServer;
@@ -231,9 +232,12 @@ class App
 
     private function runLoop()
     {
-        $http = new HttpServer(function (ServerRequestInterface $request) {
-            return $this->handleRequest($request);
-        });
+        $http = new HttpServer(...array_merge(
+            ($this->handler->hastStreamingRequest() ? [new StreamingRequestMiddleware()] : []),
+            [function (ServerRequestInterface $request) {
+                return $this->handleRequest($request);
+            }]
+        ));
 
         $listen = $this->container->getEnv('X_LISTEN') ?? '127.0.0.1:8080';
 

--- a/src/Io/MiddlewareHandler.php
+++ b/src/Io/MiddlewareHandler.php
@@ -3,6 +3,7 @@
 namespace FrameworkX\Io;
 
 use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Middleware\StreamingRequestMiddleware;
 
 /**
  * @internal
@@ -10,12 +11,18 @@ use Psr\Http\Message\ServerRequestInterface;
 class MiddlewareHandler
 {
     private $handlers;
+    private $hastStreamingRequest = false;
 
     public function __construct(array $handlers)
     {
         assert(count($handlers) >= 2);
 
         $this->handlers = $handlers;
+        foreach($this->handlers as $handler) {
+            if ($this->hastStreamingRequest = ($handler instanceof StreamingRequestMiddleware)) {
+                break;
+            }
+        }
     }
 
     public function __invoke(ServerRequestInterface $request)
@@ -32,5 +39,9 @@ class MiddlewareHandler
         return $this->handlers[$position]($request, function (ServerRequestInterface $request) use ($position) {
             return $this->call($request, $position + 1);
         });
+    }
+
+    public function hastStreamingRequest() {
+        return $this->hastStreamingRequest;
     }
 }


### PR DESCRIPTION
in respect to the underlying http-server component which will not allow to define the own middleware streaming handler. this code will give the opportunity to handle the 64KB request body problem. just assign your own 'StreamingRequestMiddleware' with custom allowed body size.