### PR TITLE
Prevent serving unparsed php files via nginx proxy.

### DIFF
--- a/docs/best-practices/deployment.md
+++ b/docs/best-practices/deployment.md
@@ -415,10 +415,14 @@ achieved by using an nginx configuration with the following contents:
 ```
 server {
     root /home/alice/projects/acme/public;
-    index index.php index.html;
+    index index.html index.htm;
 
     location / {
         try_files $uri $uri/ @x;
+    }
+
+    location ~* \.php$ {
+        try_files /dev/null @x;
     }
 
     location @x {


### PR DESCRIPTION
Currently, if using nginx as a reverse proxy with the described configuration, PHP files in the public folder are served as-it (unparsed) to the client, because the `try_files` instruction in the nginx configuration finds the file (e.g. index.php). To avoid this behavior we must instruct nginx to pass any file ending with `.php` as a route to X. That does not mean that X will parse this file, and as long as not appropriate route is defined (e.g. `$app->get('/index.php', ...`) X will just respond with a 404 error page, but at least no PHP code is leaked.
