### PR TITLE
Add PHPStan to test environment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,12 @@
 # exclude dev files from export to reduce archive download size
 /.gitattributes export-ignore
+/.github/ISSUE_TEMPLATE/ export-ignore
 /.github/workflows/ export-ignore
 /.gitignore export-ignore
 /docs/ export-ignore
 /examples/ export-ignore
 /mkdocs.yml export-ignore
+/phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore
 /phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,28 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           ini-file: development
-      - run: composer install
+      - run: composer remove --dev --no-install phpstan/phpstan && composer install
       - run: vendor/bin/phpunit --coverage-text --stderr
         if: ${{ matrix.php >= 7.3 }}
       - run: vendor/bin/phpunit --coverage-text --stderr -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
+
+  PHPStan:
+    name: PHPStan (PHP ${{ matrix.php }})
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        php:
+          - 8.2
+          - 8.1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - run: composer install
+      - run: vendor/bin/phpstan
 
   Built-in-webserver:
     name: Built-in webserver (PHP ${{ matrix.php }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           ini-file: development
-      - run: composer remove --dev --no-install phpstan/phpstan && composer install
+      - run: composer install
       - run: vendor/bin/phpunit --coverage-text --stderr
         if: ${{ matrix.php >= 7.3 }}
       - run: vendor/bin/phpunit --coverage-text --stderr -c phpunit.xml.legacy
@@ -42,6 +42,11 @@ jobs:
         php:
           - 8.2
           - 8.1
+          - 8.0
+          - 7.4
+          - 7.3
+          - 7.2
+          - 7.1
     steps:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "react/promise": "^3 || ^2.7"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.8.10",
+        "phpstan/phpstan": "1.8.10 || 1.4.10",
         "phpunit/phpunit": "^9.5 || ^7.5",
         "psr/container": "^2 || ^1"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "react/promise": "^3 || ^2.7"
     },
     "require-dev": {
+        "phpstan/phpstan": "1.8.10",
         "phpunit/phpunit": "^9.5 || ^7.5",
         "psr/container": "^2 || ^1"
     },

--- a/examples/index.php
+++ b/examples/index.php
@@ -118,7 +118,7 @@ $app->head('/method/head', function (ServerRequestInterface $request) {
    return new React\Http\Message\Response(
         React\Http\Message\Response::STATUS_OK,
         [
-            'Content-Length' => 5,
+            'Content-Length' => '5',
             'Content-Type' => 'text/plain; charset=utf-8',
             'X-Is-Head' => 'true'
         ]
@@ -161,7 +161,7 @@ $app->get('/etag/{etag:[a-z]+}', function (ServerRequestInterface $request) {
             React\Http\Message\Response::STATUS_NOT_MODIFIED,
             [
                 'ETag' => $etag,
-                'Content-Length' => strlen($etag) - 1
+                'Content-Length' => (string) (strlen($etag) - 1)
             ]
         );
     }
@@ -193,7 +193,7 @@ $app->get('/error/null', function () {
 $app->get('/error/yield', function () {
     yield null;
 });
-$app->get('/error/class', 'Acme\Http\UnknownDeleteUserController');
+$app->get('/error/class', 'Acme\Http\UnknownDeleteUserController'); // @phpstan-ignore-line
 
 // OPTIONS *
 $app->options('', function () {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,3 +10,8 @@ parameters:
     ignoreErrors:
         # ignore generic usage like `PromiseInterface<ResponseInterface>` until fixed upstream
         - '/^PHPDoc tag @return contains generic type React\\Promise\\PromiseInterface<Psr\\Http\\Message\\ResponseInterface> but interface React\\Promise\\PromiseInterface is not generic\.$/'
+        # ignore unknown `Fiber` class (PHP 8.1+)
+        - '/^Instantiated class Fiber not found\.$/'
+        - '/^Call to method (start|isTerminated|getReturn)\(\) on an unknown class Fiber\.$/'
+        # ignore incomplete type information for mocks in legacy PHPUnit 7.5
+        - '/^Parameter #\d+ \$.+ of class .+ constructor expects .+, PHPUnit\\Framework\\MockObject\\MockObject given\.$/'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,12 @@
+parameters:
+    level: 5
+
+    paths:
+        - examples/
+        - src/
+        - tests/
+
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        # ignore generic usage like `PromiseInterface<ResponseInterface>` until fixed upstream
+        - '/^PHPDoc tag @return contains generic type React\\Promise\\PromiseInterface<Psr\\Http\\Message\\ResponseInterface> but interface React\\Promise\\PromiseInterface is not generic\.$/'

--- a/src/App.php
+++ b/src/App.php
@@ -286,7 +286,7 @@ class App
         } while (true);
 
         // remove signal handlers when loop stops (if registered)
-        Loop::removeSignal(\defined('SIGINT') ? \SIGINT : 2, $f1);
+        Loop::removeSignal(\defined('SIGINT') ? \SIGINT : 2, $f1 ?? 'printf');
         Loop::removeSignal(\defined('SIGTERM') ? \SIGTERM : 15, $f2 ?? 'printf');
     }
 
@@ -309,11 +309,12 @@ class App
 
     /**
      * @param ServerRequestInterface $request
-     * @return ResponseInterface|PromiseInterface<ResponseInterface,void>
+     * @return ResponseInterface|PromiseInterface<ResponseInterface>
      *     Returns a response or a Promise which eventually fulfills with a
      *     response. This method never throws or resolves a rejected promise.
      *     If the request can not be routed or the handler fails, it will be
      *     turned into a valid error response before returning.
+     * @throws void
      */
     private function handleRequest(ServerRequestInterface $request)
     {

--- a/src/Container.php
+++ b/src/Container.php
@@ -234,6 +234,7 @@ class Container
         $hasDefault = $parameter->isDefaultValueAvailable() || ((!$type instanceof \ReflectionNamedType || $type->getName() !== 'mixed') && $parameter->allowsNull());
 
         // abort for union types (PHP 8.0+) and intersection types (PHP 8.1+)
+        // @phpstan-ignore-next-line for PHP < 8
         if ($type instanceof \ReflectionUnionType || $type instanceof \ReflectionIntersectionType) { // @codeCoverageIgnoreStart
             if ($hasDefault) {
                 return $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;

--- a/src/Container.php
+++ b/src/Container.php
@@ -13,9 +13,10 @@ class Container
     /** @var array<string,object|callable():(object|scalar|null)|scalar|null>|ContainerInterface */
     private $container;
 
-    /** @var array<string,callable():(object|scalar|null) | object | scalar | null>|ContainerInterface $loader */
+    /** @param array<string,callable():(object|scalar|null) | object | scalar | null>|ContainerInterface $loader */
     public function __construct($loader = [])
     {
+        /** @var mixed $loader explicit type check for mixed if user ignores parameter type */
         if (!\is_array($loader) && !$loader instanceof ContainerInterface) {
             throw new \TypeError(
                 'Argument #1 ($loader) must be of type array|Psr\Container\ContainerInterface, ' . (\is_object($loader) ? get_class($loader) : gettype($loader)) . ' given'

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -22,7 +22,7 @@ class ErrorHandler
     }
 
     /**
-     * @return ResponseInterface|PromiseInterface<ResponseInterface,void>|\Generator
+     * @return ResponseInterface|PromiseInterface<ResponseInterface>|\Generator
      *     Returns a response, a Promise which eventually fulfills with a
      *     response or a Generator which eventually returns a response. This
      *     method never throws or resolves a rejected promise. If the next

--- a/src/Io/SapiHandler.php
+++ b/src/Io/SapiHandler.php
@@ -46,7 +46,7 @@ class SapiHandler
         $target = ($_SERVER['REQUEST_URI'] ?? '/');
         $url = $target;
         if (($target[0] ?? '/') === '/' || $target === '*') {
-            $url = ($_SERVER['HTTPS'] ?? null === 'on' ? 'https://' : 'http://') . ($host ?? 'localhost') . ($target === '*' ? '' : $target);
+            $url = (($_SERVER['HTTPS'] ?? null) === 'on' ? 'https://' : 'http://') . ($host ?? 'localhost') . ($target === '*' ? '' : $target);
         }
 
         $body = file_get_contents('php://input');

--- a/tests/AccessLogHandlerTest.php
+++ b/tests/AccessLogHandlerTest.php
@@ -143,7 +143,7 @@ class AccessLogHandlerTest extends TestCase
         $response = new Response(200, [], "Hello\n");
 
         $generator = $handler($request, function () use ($response) {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
             return $response;

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1230,7 +1230,7 @@ class AppTest extends TestCase
         $app = $this->createAppWithoutLogger();
 
         $app->get('/users', function () {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
 
@@ -1611,7 +1611,7 @@ class AppTest extends TestCase
 
         $line = __LINE__ + 5;
         $app->get('/users', function () {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
             throw new \RuntimeException('Foo');
@@ -1837,7 +1837,7 @@ class AppTest extends TestCase
     {
         $app = $this->createAppWithoutLogger();
 
-        $app->get('/users', 'UnknownClass');
+        $app->get('/users', 'UnknownClass'); // @phpstan-ignore-line
 
         $request = new ServerRequest('GET', 'http://localhost/users');
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -137,7 +137,7 @@ class ContainerTest extends TestCase
         $controller = new class(null) {
             private $data = false;
 
-            #[PHP8] public function __construct(string|int|null $data) { $this->data = $data; }
+            #[PHP8] public function __construct(string|int|null $data) { $this->data = $data; } // @phpstan-ignore-line
 
             public function __invoke(ServerRequestInterface $request)
             {
@@ -226,7 +226,7 @@ class ContainerTest extends TestCase
         $controller = new class(null) {
             private $data = false;
 
-            #[PHP8] public function __construct(string|int|null $data = 42) { $this->data = $data; }
+            #[PHP8] public function __construct(string|int|null $data = 42) { $this->data = $data; } // @phpstan-ignore-line
 
             public function __invoke(ServerRequestInterface $request)
             {
@@ -284,7 +284,7 @@ class ContainerTest extends TestCase
         $controller = new class(null) {
             private $data = false;
 
-            #[PHP8] public function __construct(mixed $data = 'empty') { $this->data = $data; }
+            #[PHP8] public function __construct(mixed $data = 'empty') { $this->data = $data; } // @phpstan-ignore-line
 
             public function __invoke(ServerRequestInterface $request)
             {
@@ -773,7 +773,8 @@ class ContainerTest extends TestCase
             }
         };
 
-        $fn = #[PHP8] fn(mixed $data = 42) => new Response(200, [], json_encode($data));
+        $fn = null;
+        $fn = #[PHP8] fn(mixed $data = 42) => new Response(200, [], json_encode($data)); // @phpstan-ignore-line
         $container = new Container([
             ResponseInterface::class => $fn,
             'data' => null
@@ -844,7 +845,7 @@ class ContainerTest extends TestCase
             ResponseInterface::class => function (?\stdClass $user, ?\stdClass $data) {
                 return new Response(200, [], json_encode(['user' => $user, 'data' => $data]));
             },
-            'user' => function (): ?\stdClass {
+            'user' => function (): ?\stdClass { // @phpstan-ignore-line
                 return (object) [];
             }
         ]);
@@ -1717,7 +1718,7 @@ class ContainerTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Map for all contains unexpected array');
 
-        new Container([
+        new Container([ // @phpstan-ignore-line
             'all' => []
         ]);
     }
@@ -1944,7 +1945,7 @@ class ContainerTest extends TestCase
 
         $container = new Container($psr);
 
-        $callable = $container->callable('FooBar');
+        $callable = $container->callable('FooBar'); // @phpstan-ignore-line
 
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Request handler class FooBar failed to load: Unable to load class');
@@ -2175,6 +2176,6 @@ class ContainerTest extends TestCase
     {
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Argument #1 ($loader) must be of type array|Psr\Container\ContainerInterface, stdClass given');
-        new Container((object) []);
+        new Container((object) []); // @phpstan-ignore-line
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -134,6 +134,7 @@ class ContainerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
+        // @phpstan-ignore-next-line for PHP < 8
         $controller = new class(null) {
             private $data = false;
 
@@ -223,6 +224,7 @@ class ContainerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
+        // @phpstan-ignore-next-line for PHP < 8
         $controller = new class(null) {
             private $data = false;
 
@@ -281,6 +283,7 @@ class ContainerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
+        // @phpstan-ignore-next-line for PHP < 8
         $controller = new class(null) {
             private $data = false;
 

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -53,7 +53,7 @@ class ErrorHandlerTest extends TestCase
         $response = new Response();
 
         $generator = $handler($request, function () use ($response) {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
             return $response;
@@ -166,7 +166,7 @@ class ErrorHandlerTest extends TestCase
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $generator = $handler($request, function () {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
             throw new \RuntimeException();
@@ -324,7 +324,7 @@ class ErrorHandlerTest extends TestCase
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $generator = $handler($request, function () {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
             return null;

--- a/tests/Fixtures/InvalidConstructorInt.php
+++ b/tests/Fixtures/InvalidConstructorInt.php
@@ -6,5 +6,6 @@ class InvalidConstructorInt
 {
     public function __construct(int $value)
     {
+        assert(is_int($value));
     }
 }

--- a/tests/Fixtures/InvalidConstructorIntersection.php
+++ b/tests/Fixtures/InvalidConstructorIntersection.php
@@ -5,8 +5,6 @@ namespace FrameworkX\Tests\Fixtures;
 /** PHP 8.1+ **/
 class InvalidConstructorIntersection
 {
-    public function __construct(\Traversable&\ArrayAccess $value)
-    {
-        assert($value instanceof \Traversable && $value instanceof \ArrayAccess); // @phpstan-ignore-line
-    }
+    // @phpstan-ignore-next-line for PHP < 8
+    #[PHP8] public function __construct(\Traversable&\ArrayAccess $value) { assert($value instanceof \Traversable && $value instanceof \ArrayAccess); }
 }

--- a/tests/Fixtures/InvalidConstructorIntersection.php
+++ b/tests/Fixtures/InvalidConstructorIntersection.php
@@ -7,5 +7,6 @@ class InvalidConstructorIntersection
 {
     public function __construct(\Traversable&\ArrayAccess $value)
     {
+        assert($value instanceof \Traversable && $value instanceof \ArrayAccess); // @phpstan-ignore-line
     }
 }

--- a/tests/Fixtures/InvalidConstructorSelf.php
+++ b/tests/Fixtures/InvalidConstructorSelf.php
@@ -6,5 +6,6 @@ class InvalidConstructorSelf
 {
     public function __construct(InvalidConstructorSelf $value)
     {
+        assert($value instanceof self);
     }
 }

--- a/tests/Fixtures/InvalidConstructorUnion.php
+++ b/tests/Fixtures/InvalidConstructorUnion.php
@@ -5,8 +5,6 @@ namespace FrameworkX\Tests\Fixtures;
 /** PHP 8.0+ **/
 class InvalidConstructorUnion
 {
-    public function __construct(int|float $value)
-    {
-        assert(is_int($value) || is_float($value)); // @phpstan-ignore-line
-    }
+    // @phpstan-ignore-next-line for PHP < 8
+    #[PHP8] public function __construct(int|float $value) { assert(is_int($value) || is_float($value)); }
 }

--- a/tests/Fixtures/InvalidConstructorUnion.php
+++ b/tests/Fixtures/InvalidConstructorUnion.php
@@ -7,5 +7,6 @@ class InvalidConstructorUnion
 {
     public function __construct(int|float $value)
     {
+        assert(is_int($value) || is_float($value)); // @phpstan-ignore-line
     }
 }

--- a/tests/Fixtures/InvalidConstructorUnknown.php
+++ b/tests/Fixtures/InvalidConstructorUnknown.php
@@ -4,7 +4,7 @@ namespace FrameworkX\Tests\Fixtures;
 
 class InvalidConstructorUnknown
 {
-    public function __construct(\UnknownClass $value)
+    public function __construct(\UnknownClass $value) // @phpstan-ignore-line
     {
     }
 }

--- a/tests/Fixtures/InvalidConstructorUntyped.php
+++ b/tests/Fixtures/InvalidConstructorUntyped.php
@@ -4,7 +4,9 @@ namespace FrameworkX\Tests\Fixtures;
 
 class InvalidConstructorUntyped
 {
+    /** @param mixed $value */
     public function __construct($value)
     {
+        assert($value === $value);
     }
 }

--- a/tests/Io/FiberHandlerTest.php
+++ b/tests/Io/FiberHandlerTest.php
@@ -61,7 +61,7 @@ class FiberHandlerTest extends TestCase
         $response = new Response();
 
         $generator = $handler($request, function () use ($response) {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
             return $response;

--- a/tests/Io/RouteHandlerTest.php
+++ b/tests/Io/RouteHandlerTest.php
@@ -200,6 +200,7 @@ class RouteHandlerTest extends TestCase
         $controller = new class {
             public static $response;
             public function __construct(int $value = null) {
+                assert($value === null);
             }
             public function __invoke() {
                 return self::$response;
@@ -223,6 +224,7 @@ class RouteHandlerTest extends TestCase
         $controller = new class(null) {
             public static $response;
             public function __construct(?int $value) {
+                assert($value === null);
             }
             public function __invoke() {
                 return self::$response;

--- a/tests/Io/SapiHandlerTest.php
+++ b/tests/Io/SapiHandlerTest.php
@@ -216,7 +216,7 @@ class SapiHandlerTest extends TestCase
 
         $_SERVER['SERVER_PROTOCOL'] = 'http/1.1';
         $sapi = new SapiHandler();
-        $response = new Response(204, ['Content-Type' => 'application/json', 'Content-Length' => 2], '{}');
+        $response = new Response(204, ['Content-Type' => 'application/json', 'Content-Length' => '2'], '{}');
 
         $this->expectOutputString('');
         $sapi->sendResponse($response);


### PR DESCRIPTION
This changeset adds PHPStan to the test environment for all supported PHP versions. This intentionally starts small with level 5 only to avoid most common issues that can be detected with static analysis.

Adding PHPStan for newer PHP versions is relative straight forward, most of the work in this PR went into making sure this works across the entire test matrix. I consider this to be a decent starting point to increase the level and/or introduce a baseline in a follow-up PR in the future.

Refs #199 and https://github.com/phpstan/phpstan/issues/4060