### PR TITLE
Improve type definitions and update to PHPStan level `max`

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -21,8 +21,11 @@ $app->get('/users/{name}', function (Psr\Http\Message\ServerRequestInterface $re
         return htmlspecialchars_decode(htmlspecialchars($str, ENT_SUBSTITUTE | ENT_DISALLOWED, 'utf-8'));
     };
 
+    $name = $request->getAttribute('name');
+    assert(is_string($name));
+
     return React\Http\Message\Response::plaintext(
-        "Hello " . $escape($request->getAttribute('name')) . "!\n"
+        "Hello " . $escape($name) . "!\n"
     );
 });
 
@@ -202,9 +205,10 @@ $app->options('', function () {
 });
 
 $app->get('/location/{status:\d+}', function (Psr\Http\Message\ServerRequestInterface $request) {
-    $statusCode = (int) $request->getAttribute('status');
+    $statusCode = $request->getAttribute('status');
+    assert(is_string($statusCode) && is_numeric($statusCode));
 
-    return new React\Http\Message\Response($statusCode, ['Location' => '/foobar']);
+    return new React\Http\Message\Response((int) $statusCode, ['Location' => '/foobar']);
 });
 
 $app->run();

--- a/examples/index.php
+++ b/examples/index.php
@@ -63,6 +63,7 @@ $app->get('/debug', function (ServerRequestInterface $request) {
     ob_start();
     var_dump($request);
     $info = ob_get_clean();
+    assert(is_string($info));
 
     if (PHP_SAPI !== 'cli' && (!function_exists('xdebug_is_enabled') || !xdebug_is_enabled())) {
         $info = htmlspecialchars($info, 0, 'utf-8');

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
 
     paths:
         - examples/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 8
+    level: max
 
     paths:
         - examples/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 7
 
     paths:
         - examples/
@@ -14,4 +14,4 @@ parameters:
         - '/^Instantiated class Fiber not found\.$/'
         - '/^Call to method (start|isTerminated|getReturn)\(\) on an unknown class Fiber\.$/'
         # ignore incomplete type information for mocks in legacy PHPUnit 7.5
-        - '/^Parameter #\d+ \$.+ of class .+ constructor expects .+, PHPUnit\\Framework\\MockObject\\MockObject given\.$/'
+        - '/^Parameter #\d+ .+ of .+ expects .+, PHPUnit\\Framework\\MockObject\\MockObject given\.$/'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 8
 
     paths:
         - examples/

--- a/src/AccessLogHandler.php
+++ b/src/AccessLogHandler.php
@@ -94,7 +94,7 @@ class AccessLogHandler
 
     private function escape(string $s): string
     {
-        return preg_replace_callback('/[\x00-\x1F\x7F-\xFF"\\\\]+/', function (array $m) {
+        return (string) preg_replace_callback('/[\x00-\x1F\x7F-\xFF"\\\\]+/', function (array $m) {
             return str_replace('%', '\x', rawurlencode($m[0]));
         }, $s);
     }

--- a/src/App.php
+++ b/src/App.php
@@ -220,7 +220,7 @@ class App
         $this->any($route, new RedirectHandler($target, $code));
     }
 
-    public function run()
+    public function run(): void
     {
         if (\PHP_SAPI === 'cli') {
             $this->runLoop();
@@ -229,7 +229,7 @@ class App
         }
     }
 
-    private function runLoop()
+    private function runLoop(): void
     {
         $http = new HttpServer(function (ServerRequestInterface $request) {
             return $this->handleRequest($request);
@@ -290,7 +290,7 @@ class App
         Loop::removeSignal(\defined('SIGTERM') ? \SIGTERM : 15, $f2 ?? 'printf');
     }
 
-    private function runOnce()
+    private function runOnce(): void
     {
         $request = $this->sapi->requestFromGlobals();
 

--- a/src/App.php
+++ b/src/App.php
@@ -319,11 +319,14 @@ class App
     private function handleRequest(ServerRequestInterface $request)
     {
         $response = ($this->handler)($request);
+        assert($response instanceof ResponseInterface || $response instanceof PromiseInterface || $response instanceof \Generator);
+
         if ($response instanceof \Generator) {
             if ($response->valid()) {
                 $response = $this->coroutine($response);
             } else {
                 $response = $response->getReturn();
+                assert($response instanceof ResponseInterface);
             }
         }
 
@@ -341,6 +344,8 @@ class App
             }
 
             $promise = $generator->current();
+            assert($promise instanceof PromiseInterface);
+
             $promise->then(function ($value) use ($generator, $next) {
                 $generator->send($value);
                 $next();

--- a/src/App.php
+++ b/src/App.php
@@ -240,7 +240,7 @@ class App
         $socket = new SocketServer($listen);
         $http->listen($socket);
 
-        $this->sapi->log('Listening on ' . \str_replace('tcp:', 'http:', $socket->getAddress()));
+        $this->sapi->log('Listening on ' . \str_replace('tcp:', 'http:', (string) $socket->getAddress()));
 
         $http->on('error', function (\Exception $e) {
             $orig = $e;

--- a/src/Container.php
+++ b/src/Container.php
@@ -118,6 +118,7 @@ class Container
     {
         if ($this->container instanceof ContainerInterface) {
             if ($this->container->has(AccessLogHandler::class)) {
+                // @phpstan-ignore-next-line method return type will ensure correct type or throw `TypeError`
                 return $this->container->get(AccessLogHandler::class);
             } else {
                 return new AccessLogHandler();
@@ -131,6 +132,7 @@ class Container
     {
         if ($this->container instanceof ContainerInterface) {
             if ($this->container->has(ErrorHandler::class)) {
+                // @phpstan-ignore-next-line method return type will ensure correct type or throw `TypeError`
                 return $this->container->get(ErrorHandler::class);
             } else {
                 return new ErrorHandler();
@@ -140,7 +142,7 @@ class Container
     }
 
     /**
-     * @template T
+     * @template T of object
      * @param class-string<T> $name
      * @return T
      * @throws \BadMethodCallException if object of type $name can not be loaded
@@ -158,7 +160,7 @@ class Container
                 // @phpstan-ignore-next-line because type of container value is explicitly checked after getting here
                 $value = $this->loadObject($this->container[$name], $depth - 1);
                 if (!$value instanceof $name) {
-                    throw new \BadMethodCallException('Factory for ' . $name . ' returned unexpected ' . (is_object($value) ? get_class($value) : gettype($value)));
+                    throw new \BadMethodCallException('Factory for ' . $name . ' returned unexpected ' . \get_class($value));
                 }
 
                 $this->container[$name] = $value;

--- a/src/Container.php
+++ b/src/Container.php
@@ -34,6 +34,7 @@ class Container
         $this->container = $loader;
     }
 
+    /** @return mixed */
     public function __invoke(ServerRequestInterface $request, callable $next = null)
     {
         if ($next === null) {
@@ -152,6 +153,7 @@ class Container
                     throw new \BadMethodCallException('Factory for ' . $name . ' is recursive');
                 }
 
+                // @phpstan-ignore-next-line because type of container value is explicitly checked after getting here
                 $value = $this->loadObject($this->container[$name], $depth - 1);
                 if (!$value instanceof $name) {
                     throw new \BadMethodCallException('Factory for ' . $name . ' returned unexpected ' . (is_object($value) ? get_class($value) : gettype($value)));
@@ -171,6 +173,7 @@ class Container
                         throw new \BadMethodCallException('Factory for ' . $name . ' is recursive');
                     }
 
+                    // @phpstan-ignore-next-line because type of container value is explicitly checked after getting here
                     $value = $this->loadObject($value, $depth - 1);
                 }
                 if (!$value instanceof $name) {
@@ -213,7 +216,10 @@ class Container
         return $this->container[$name] = $params === [] ? new $name() : $class->newInstance(...$params);
     }
 
-    /** @throws \BadMethodCallException if either parameter can not be loaded */
+    /**
+     * @return list<mixed>
+     * @throws \BadMethodCallException if either parameter can not be loaded
+     */
     private function loadFunctionParams(\ReflectionFunctionAbstract $function, int $depth, bool $allowVariables): array
     {
         $params = [];
@@ -277,6 +283,7 @@ class Container
             throw new \BadMethodCallException(self::parameterError($parameter) . ' is recursive');
         }
 
+        // @phpstan-ignore-next-line because `$type->getName()` is a `class-string` by definition
         return $this->loadObject($type->getName(), $depth - 1);
     }
 

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -120,7 +120,10 @@ class ErrorHandler
         );
     }
 
-    /** @internal */
+    /**
+     * @internal
+     * @param list<string> $allowedMethods
+     */
     public function requestMethodNotAllowed(array $allowedMethods): ResponseInterface
     {
         $methods = \implode('/', \array_map(function (string $method) { return '<code>' . $method . '</code>'; }, $allowedMethods));
@@ -155,6 +158,7 @@ class ErrorHandler
         );
     }
 
+    /** @param mixed $value */
     private function errorInvalidResponse($value): ResponseInterface
     {
         return $this->htmlResponse(
@@ -165,6 +169,7 @@ class ErrorHandler
         );
     }
 
+    /** @param mixed $value */
     private function errorInvalidCoroutine($value, string $file, int $line): ResponseInterface
     {
         $where = ' near or before '. $this->where($file, $line) . '.';
@@ -192,6 +197,7 @@ class ErrorHandler
         );
     }
 
+    /** @param mixed $value */
     private function describeType($value): string
     {
         if ($value === null) {

--- a/src/FilesystemHandler.php
+++ b/src/FilesystemHandler.php
@@ -4,11 +4,13 @@ namespace FrameworkX;
 
 use FrameworkX\Io\HtmlHandler;
 use FrameworkX\Io\RedirectHandler;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
 class FilesystemHandler
 {
+    /** @var string */
     private $root;
 
     /**
@@ -59,7 +61,7 @@ class FilesystemHandler
         $this->html = new HtmlHandler();
     }
 
-    public function __invoke(ServerRequestInterface $request)
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
         $local = $request->getAttribute('path', '');
         $path = \rtrim($this->root . '/' . $local, '/');

--- a/src/FilesystemHandler.php
+++ b/src/FilesystemHandler.php
@@ -82,6 +82,7 @@ class FilesystemHandler
             }
 
             $files = \scandir($path);
+            // @phpstan-ignore-next-line TODO handle error if directory can not be accessed
             foreach ($files as $file) {
                 if ($file === '.' || $file === '..') {
                     continue;
@@ -119,7 +120,7 @@ class FilesystemHandler
             return new Response(
                 Response::STATUS_OK,
                 $headers,
-                \file_get_contents($path)
+                \file_get_contents($path) // @phpstan-ignore-line TODO handle error if file can not be accessed
             );
         } else {
             return $this->errorHandler->requestNotFound();

--- a/src/FilesystemHandler.php
+++ b/src/FilesystemHandler.php
@@ -64,6 +64,7 @@ class FilesystemHandler
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
         $local = $request->getAttribute('path', '');
+        assert(\is_string($local));
         $path = \rtrim($this->root . '/' . $local, '/');
 
         // local path should not contain "./", "../", "//" or null bytes or start with slash

--- a/src/Io/FiberHandler.php
+++ b/src/Io/FiberHandler.php
@@ -56,6 +56,7 @@ class FiberHandler
         $fiber->start();
         if ($fiber->isTerminated()) {
             /** @throws void because fiber is known to have terminated successfully */
+            /** @var ResponseInterface|PromiseInterface|\Generator */
             return $fiber->getReturn();
         }
 

--- a/src/Io/HtmlHandler.php
+++ b/src/Io/HtmlHandler.php
@@ -50,12 +50,12 @@ HTML;
 
     public function escape(string $s): string
     {
-        return \preg_replace_callback(
+        return (string) \preg_replace_callback(
             '/[\x00-\x1F]+/',
             function (array $match): string {
                 return '<span>' . \addcslashes($match[0], "\x00..\xff") . '</span>';
             },
-            \preg_replace(
+            (string) \preg_replace(
                 '/(^| ) |(?: $)/',
                 '$1&nbsp;',
                 \htmlspecialchars($s, \ENT_NOQUOTES | \ENT_SUBSTITUTE | \ENT_DISALLOWED, 'utf-8')

--- a/src/Io/MiddlewareHandler.php
+++ b/src/Io/MiddlewareHandler.php
@@ -9,8 +9,10 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class MiddlewareHandler
 {
+    /** @var list<callable> $handlers */
     private $handlers;
 
+    /** @param list<callable> $handlers */
     public function __construct(array $handlers)
     {
         assert(count($handlers) >= 2);
@@ -18,11 +20,13 @@ class MiddlewareHandler
         $this->handlers = $handlers;
     }
 
+    /** @return mixed */
     public function __invoke(ServerRequestInterface $request)
     {
         return $this->call($request, 0);
     }
 
+    /** @return mixed */
     private function call(ServerRequestInterface $request, int $position)
     {
         if (!isset($this->handlers[$position + 2])) {

--- a/src/Io/RedirectHandler.php
+++ b/src/Io/RedirectHandler.php
@@ -10,8 +10,13 @@ use React\Http\Message\Response;
  */
 class RedirectHandler
 {
+    /** @var string */
     private $target;
+
+    /** @var int */
     private $code;
+
+    /** @var string */
     private $reason;
 
     /** @var HtmlHandler */

--- a/src/Io/RouteHandler.php
+++ b/src/Io/RouteHandler.php
@@ -65,6 +65,7 @@ class RouteHandler
             }
         }
 
+        /** @var non-empty-array<callable> $handlers */
         $handler = \count($handlers) > 1 ? new MiddlewareHandler(array_values($handlers)) : \reset($handlers);
         $this->routeDispatcher = null;
         $this->routeCollector->addRoute($methods, $route, $handler);

--- a/src/Io/SapiHandler.php
+++ b/src/Io/SapiHandler.php
@@ -18,6 +18,7 @@ class SapiHandler
 
     public function __construct()
     {
+        // @phpstan-ignore-next-line because `fopen()` is known to always return a `resource` for built-in wrappers
         $this->logStream = PHP_SAPI === 'cli' ? \fopen('php://output', 'a') : (\defined('STDERR') ? \STDERR : \fopen('php://stderr', 'a'));
     }
 
@@ -50,6 +51,7 @@ class SapiHandler
         }
 
         $body = file_get_contents('php://input');
+        assert(\is_string($body));
 
         $request = new ServerRequest(
             $_SERVER['REQUEST_METHOD'] ?? 'GET',
@@ -102,6 +104,7 @@ class SapiHandler
 
         // send all headers without applying default "; charset=utf-8" set by PHP (default_charset)
         $old = ini_get('default_charset');
+        assert(\is_string($old));
         ini_set('default_charset', '');
         foreach ($response->getHeaders() as $name => $values) {
             foreach ($values as $value) {

--- a/tests/AccessLogHandlerTest.php
+++ b/tests/AccessLogHandlerTest.php
@@ -11,7 +11,7 @@ use function React\Promise\resolve;
 
 class AccessLogHandlerTest extends TestCase
 {
-    public function testInvokePrintsRequestLogWithCurrentDateAndTime()
+    public function testInvokePrintsRequestLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -23,7 +23,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokePrintsRequestWithQueryParametersLogWithCurrentDateAndTime()
+    public function testInvokePrintsRequestWithQueryParametersLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -35,7 +35,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokePrintsRequestWithEscapedSpecialCharactersInRequestMethodAndTargetWithCurrentDateAndTime()
+    public function testInvokePrintsRequestWithEscapedSpecialCharactersInRequestMethodAndTargetWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -48,7 +48,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokePrintsRequestLogForHeadRequestWithResponseSizeAsZero()
+    public function testInvokePrintsRequestLogForHeadRequestWithResponseSizeAsZero(): void
     {
         $handler = new AccessLogHandler();
 
@@ -60,7 +60,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokePrintsRequestLogForNoContentResponseWithResponseSizeAsZero()
+    public function testInvokePrintsRequestLogForNoContentResponseWithResponseSizeAsZero(): void
     {
         $handler = new AccessLogHandler();
 
@@ -72,7 +72,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokePrintsRequestLogForNotModifiedResponseWithResponseSizeAsZero()
+    public function testInvokePrintsRequestLogForNotModifiedResponseWithResponseSizeAsZero(): void
     {
         $handler = new AccessLogHandler();
 
@@ -84,7 +84,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokePrintsPlainProxyRequestLogWithCurrentDateAndTime()
+    public function testInvokePrintsPlainProxyRequestLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -97,7 +97,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokePrintsConnectProxyRequestLogWithCurrentDateAndTime()
+    public function testInvokePrintsConnectProxyRequestLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -110,7 +110,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokePrintsOptionsAsteriskLogWithCurrentDateAndTime()
+    public function testInvokePrintsOptionsAsteriskLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -123,7 +123,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokeWithDeferredNextPrintsRequestLogWithCurrentDateAndTime()
+    public function testInvokeWithDeferredNextPrintsRequestLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -135,7 +135,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return resolve($response); });
     }
 
-    public function testInvokeWithCoroutineNextPrintsRequestLogWithCurrentDateAndTime()
+    public function testInvokeWithCoroutineNextPrintsRequestLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -157,7 +157,7 @@ class AccessLogHandlerTest extends TestCase
         $generator->next();
     }
 
-    public function testInvokeWithStreamingResponsePrintsRequestLogWithCurrentDateAndTime()
+    public function testInvokeWithStreamingResponsePrintsRequestLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -172,7 +172,7 @@ class AccessLogHandlerTest extends TestCase
         $stream->end('world');
     }
 
-    public function testInvokeWithStreamingResponseThatClosesAfterSomeTimePrintsRequestLogWithCurrentDateAndTime()
+    public function testInvokeWithStreamingResponseThatClosesAfterSomeTimePrintsRequestLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -188,7 +188,7 @@ class AccessLogHandlerTest extends TestCase
         $stream->end();
     }
 
-    public function testInvokeWithClosedStreamingResponsePrintsRequestLogWithCurrentDateAndTime()
+    public function testInvokeWithClosedStreamingResponsePrintsRequestLogWithCurrentDateAndTime(): void
     {
         $handler = new AccessLogHandler();
 
@@ -202,7 +202,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokeWithStreamingResponsePrintsNothingIfStreamIsPending()
+    public function testInvokeWithStreamingResponsePrintsNothingIfStreamIsPending(): void
     {
         $handler = new AccessLogHandler();
 
@@ -215,7 +215,7 @@ class AccessLogHandlerTest extends TestCase
         $stream->write('hello');
     }
 
-    public function testInvokeWithRemoteAddrAttributePrintsRequestLogWithIpFromAttribute()
+    public function testInvokeWithRemoteAddrAttributePrintsRequestLogWithIpFromAttribute(): void
     {
         $handler = new AccessLogHandler();
 
@@ -228,7 +228,7 @@ class AccessLogHandlerTest extends TestCase
         $handler($request, function () use ($response) { return $response; });
     }
 
-    public function testInvokeWithoutRemoteAddressPrintsRequestLogWithDashAsPlaceholder()
+    public function testInvokeWithoutRemoteAddressPrintsRequestLogWithDashAsPlaceholder(): void
     {
         $handler = new AccessLogHandler();
 

--- a/tests/AppMiddlewareTest.php
+++ b/tests/AppMiddlewareTest.php
@@ -16,7 +16,7 @@ use function React\Promise\resolve;
 
 class AppMiddlewareTest extends TestCase
 {
-    public function testGetMethodWithMiddlewareAddsGetRouteOnRouter()
+    public function testGetMethodWithMiddlewareAddsGetRouteOnRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -33,7 +33,7 @@ class AppMiddlewareTest extends TestCase
         $app->get('/', $middleware, $controller);
     }
 
-    public function testHeadMethodWithMiddlewareAddsHeadRouteOnRouter()
+    public function testHeadMethodWithMiddlewareAddsHeadRouteOnRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -50,7 +50,7 @@ class AppMiddlewareTest extends TestCase
         $app->head('/', $middleware, $controller);
     }
 
-    public function testPostMethodWithMiddlewareAddsPostRouteOnRouter()
+    public function testPostMethodWithMiddlewareAddsPostRouteOnRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -67,7 +67,7 @@ class AppMiddlewareTest extends TestCase
         $app->post('/', $middleware, $controller);
     }
 
-    public function testPutMethodWithMiddlewareAddsPutRouteOnRouter()
+    public function testPutMethodWithMiddlewareAddsPutRouteOnRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -84,7 +84,7 @@ class AppMiddlewareTest extends TestCase
         $app->put('/', $middleware, $controller);
     }
 
-    public function testPatchMethodWithMiddlewareAddsPatchRouteOnRouter()
+    public function testPatchMethodWithMiddlewareAddsPatchRouteOnRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -101,7 +101,7 @@ class AppMiddlewareTest extends TestCase
         $app->patch('/', $middleware, $controller);
     }
 
-    public function testDeleteMethodWithMiddlewareAddsDeleteRouteOnRouter()
+    public function testDeleteMethodWithMiddlewareAddsDeleteRouteOnRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -118,7 +118,7 @@ class AppMiddlewareTest extends TestCase
         $app->delete('/', $middleware, $controller);
     }
 
-    public function testOptionsMethodWithMiddlewareAddsOptionsRouteOnRouter()
+    public function testOptionsMethodWithMiddlewareAddsOptionsRouteOnRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -135,7 +135,7 @@ class AppMiddlewareTest extends TestCase
         $app->options('/', $middleware, $controller);
     }
 
-    public function testAnyMethodWithMiddlewareAddsAllHttpMethodsOnRouter()
+    public function testAnyMethodWithMiddlewareAddsAllHttpMethodsOnRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -152,7 +152,7 @@ class AppMiddlewareTest extends TestCase
         $app->any('/', $middleware, $controller);
     }
 
-    public function testMapMethodWithMiddlewareAddsGivenMethodsOnRouter()
+    public function testMapMethodWithMiddlewareAddsGivenMethodsOnRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -169,7 +169,7 @@ class AppMiddlewareTest extends TestCase
         $app->map(['GET', 'POST'], '/', $middleware, $controller);
     }
 
-    public function testMiddlewareCallsNextReturnsResponseFromRouter()
+    public function testMiddlewareCallsNextReturnsResponseFromRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -203,7 +203,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testMiddlewareCallsNextWithModifiedRequestReturnsResponseFromRouter()
+    public function testMiddlewareCallsNextWithModifiedRequestReturnsResponseFromRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -237,7 +237,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals('Alice', (string) $response->getBody());
     }
 
-    public function testMiddlewareCallsNextReturnsResponseModifiedInMiddlewareFromRouter()
+    public function testMiddlewareCallsNextReturnsResponseModifiedInMiddlewareFromRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -272,7 +272,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals('Alice', (string) $response->getBody());
     }
 
-    public function testMiddlewareCallsNextReturnsDeferredResponseModifiedInMiddlewareFromRouter()
+    public function testMiddlewareCallsNextReturnsDeferredResponseModifiedInMiddlewareFromRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -317,7 +317,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals('Alice', (string) $response->getBody());
     }
 
-    public function testMiddlewareCallsNextReturnsCoroutineResponseModifiedInMiddlewareFromRouter()
+    public function testMiddlewareCallsNextReturnsCoroutineResponseModifiedInMiddlewareFromRouter(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -364,7 +364,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals('Alice', (string) $response->getBody());
     }
 
-    public function testMiddlewareCallsNextWhichThrowsExceptionReturnsInternalServerErrorResponse()
+    public function testMiddlewareCallsNextWhichThrowsExceptionReturnsInternalServerErrorResponse(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -395,7 +395,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>Foo</code> in <code title=\"See " . __FILE__ . " line $line\">AppMiddlewareTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testMiddlewareWhichThrowsExceptionReturnsInternalServerErrorResponse()
+    public function testMiddlewareWhichThrowsExceptionReturnsInternalServerErrorResponse(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -424,7 +424,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>Foo</code> in <code title=\"See " . __FILE__ . " line $line\">AppMiddlewareTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testGlobalMiddlewareCallsNextReturnsResponseFromController()
+    public function testGlobalMiddlewareCallsNextReturnsResponseFromController(): void
     {
         $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             return $next($request);
@@ -454,10 +454,10 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testGlobalMiddlewareInstanceCallsNextReturnsResponseFromController()
+    public function testGlobalMiddlewareInstanceCallsNextReturnsResponseFromController(): void
     {
         $middleware = new class {
-            public function __invoke(ServerRequestInterface $request, callable $next)
+            public function __invoke(ServerRequestInterface $request, callable $next): Response
             {
                 return $next($request);
             }
@@ -489,10 +489,10 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testGlobalMiddlewareClassNameCallsNextReturnsResponseFromController()
+    public function testGlobalMiddlewareClassNameCallsNextReturnsResponseFromController(): void
     {
         $middleware = new class {
-            public function __invoke(ServerRequestInterface $request, callable $next)
+            public function __invoke(ServerRequestInterface $request, callable $next): Response
             {
                 return $next($request);
             }
@@ -524,11 +524,12 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testGlobalMiddlewareClassNameAndSameForRouterCallsSameMiddlewareInstanceTwiceAndNextReturnsResponseFromController()
+    public function testGlobalMiddlewareClassNameAndSameForRouterCallsSameMiddlewareInstanceTwiceAndNextReturnsResponseFromController(): void
     {
         $middleware = new class {
+            /** @var int */
             private $called = 0;
-            public function __invoke(ServerRequestInterface $request, callable $next)
+            public function __invoke(ServerRequestInterface $request, callable $next): Response
             {
                 return $next($request->withAttribute('called', ++$this->called));
             }
@@ -560,9 +561,9 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals("2\n", (string) $response->getBody());
     }
 
-    public function testGlobalMiddlewareCallsNextWithModifiedRequestWillBeUsedForRouting()
+    public function testGlobalMiddlewareCallsNextWithModifiedRequestWillBeUsedForRouting(): void
     {
-        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
+        $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next): Response {
             return $next($request->withUri($request->getUri()->withPath('/users')));
         });
 
@@ -590,7 +591,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testGlobalMiddlewareCallsNextReturnsModifiedResponseWhenModifyingResponseFromRouter()
+    public function testGlobalMiddlewareCallsNextReturnsModifiedResponseWhenModifyingResponseFromRouter(): void
     {
         $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             $response = $next($request);
@@ -621,7 +622,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testGlobalMiddlewareReturnsResponseWithoutCallingNextReturnsResponseWithoutCallingRouter()
+    public function testGlobalMiddlewareReturnsResponseWithoutCallingNextReturnsResponseWithoutCallingRouter(): void
     {
         $app = $this->createAppWithoutLogger(function () {
             return new Response(
@@ -654,7 +655,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertFalse($called);
     }
 
-    public function testGlobalMiddlewareReturnsPromiseWhichResolvesWithResponseWithoutCallingNextDoesNotCallRouter()
+    public function testGlobalMiddlewareReturnsPromiseWhichResolvesWithResponseWithoutCallingNextDoesNotCallRouter(): void
     {
         $app = $this->createAppWithoutLogger(function () {
             return resolve(new Response(
@@ -695,7 +696,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertFalse($called);
     }
 
-    public function testGlobalMiddlewareCallsNextReturnsPromiseWhichResolvesWithModifiedResponseWhenModifyingPromiseWhichResolvesToResponseFromRouter()
+    public function testGlobalMiddlewareCallsNextReturnsPromiseWhichResolvesWithModifiedResponseWhenModifyingPromiseWhichResolvesToResponseFromRouter(): void
     {
         $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             return $next($request)->then(function (ResponseInterface $response) {
@@ -733,7 +734,7 @@ class AppMiddlewareTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testGlobalMiddlewareCallsNextReturnsPromiseWhichResolvesWithModifiedResponseWhenModifyingCoroutineWhichYieldsResponseFromRouter()
+    public function testGlobalMiddlewareCallsNextReturnsPromiseWhichResolvesWithModifiedResponseWhenModifyingCoroutineWhichYieldsResponseFromRouter(): void
     {
         $app = $this->createAppWithoutLogger(function (ServerRequestInterface $request, callable $next) {
             $generator = $next($request);

--- a/tests/AppMiddlewareTest.php
+++ b/tests/AppMiddlewareTest.php
@@ -5,6 +5,7 @@ namespace FrameworkX\Tests;
 use FrameworkX\AccessLogHandler;
 use FrameworkX\App;
 use FrameworkX\Io\FiberHandler;
+use FrameworkX\Io\MiddlewareHandler;
 use FrameworkX\Io\RouteHandler;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -217,7 +218,7 @@ class AppMiddlewareTest extends TestCase
                 [
                     'Content-Type' => 'text/html'
                 ],
-                $request->getAttribute('name')
+                $request->getAttribute('name') // @phpstan-ignore-line known to return string
             );
         };
 
@@ -786,10 +787,12 @@ class AppMiddlewareTest extends TestCase
         $ref = new \ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $middleware = $ref->getValue($app);
+        assert($middleware instanceof MiddlewareHandler);
 
         $ref = new \ReflectionProperty($middleware, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($middleware);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -46,11 +46,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -78,11 +79,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -112,11 +114,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -144,11 +147,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -168,11 +172,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -194,11 +199,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -223,11 +229,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -255,11 +262,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -288,11 +296,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -316,11 +325,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -356,11 +366,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -385,11 +396,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -409,11 +421,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -440,11 +453,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -468,11 +482,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -505,11 +520,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -543,11 +559,12 @@ class AppTest extends TestCase
         $ref = new ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $handler = $ref->getValue($app);
+        assert($handler instanceof MiddlewareHandler);
 
-        $this->assertInstanceOf(MiddlewareHandler::class, $handler);
         $ref = new ReflectionProperty($handler, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);
@@ -1458,6 +1475,7 @@ class AppTest extends TestCase
 
         $app->get('/users/{name}', function (ServerRequestInterface $request) {
             $name = $request->getAttribute('name');
+            assert(is_string($name));
 
             return new Response(
                 200,
@@ -2091,10 +2109,12 @@ class AppTest extends TestCase
         $ref = new \ReflectionProperty($app, 'handler');
         $ref->setAccessible(true);
         $middleware = $ref->getValue($app);
+        assert($middleware instanceof MiddlewareHandler);
 
         $ref = new \ReflectionProperty($middleware, 'handlers');
         $ref->setAccessible(true);
         $handlers = $ref->getValue($middleware);
+        assert(is_array($handlers));
 
         if (PHP_VERSION_ID >= 80100) {
             $first = array_shift($handlers);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -584,6 +584,7 @@ class AppTest extends TestCase
         if ($socket === false) {
             $this->markTestSkipped('Listen address :8080 already in use');
         }
+        assert(is_resource($socket));
         fclose($socket);
 
         $app = new App();
@@ -592,6 +593,7 @@ class AppTest extends TestCase
         Loop::futureTick(function () {
             $resources = get_resources();
             $socket = end($resources);
+            assert(is_resource($socket));
 
             Loop::removeReadStream($socket);
             fclose($socket);
@@ -605,7 +607,8 @@ class AppTest extends TestCase
 
     public function testRunWillReportListeningAddressFromContainerEnvironmentAndRunLoopWithSocketServer(): void
     {
-        $socket = @stream_socket_server('127.0.0.1:0');
+        $socket = stream_socket_server('127.0.0.1:0');
+        assert(is_resource($socket));
         $addr = stream_socket_get_name($socket, false);
         fclose($socket);
 
@@ -619,6 +622,7 @@ class AppTest extends TestCase
         Loop::futureTick(function () {
             $resources = get_resources();
             $socket = end($resources);
+            assert(is_resource($socket));
 
             Loop::removeReadStream($socket);
             fclose($socket);
@@ -642,6 +646,7 @@ class AppTest extends TestCase
         Loop::futureTick(function () {
             $resources = get_resources();
             $socket = end($resources);
+            assert(is_resource($socket));
 
             Loop::removeReadStream($socket);
             fclose($socket);
@@ -665,6 +670,7 @@ class AppTest extends TestCase
         Loop::futureTick(function () {
             $resources = get_resources();
             $socket = end($resources);
+            assert(is_resource($socket));
 
             Loop::futureTick(function () use ($socket) {
                 Loop::removeReadStream($socket);
@@ -693,7 +699,9 @@ class AppTest extends TestCase
         $app = new App($container);
 
         Loop::futureTick(function () {
-            posix_kill(getmypid(), defined('SIGINT') ? SIGINT : 2);
+            $pid = getmypid();
+            assert(is_int($pid));
+            posix_kill($pid, defined('SIGINT') ? SIGINT : 2);
         });
 
         $this->expectOutputRegex('/' . preg_quote('Received SIGINT, stopping loop' . PHP_EOL, '/') . '$/');
@@ -713,7 +721,9 @@ class AppTest extends TestCase
         $app = new App($container);
 
         Loop::futureTick(function () {
-            posix_kill(getmypid(), defined('SIGTERM') ? SIGTERM : 15);
+            $pid = getmypid();
+            assert(is_int($pid));
+            posix_kill($pid, defined('SIGTERM') ? SIGTERM : 15);
         });
 
         $this->expectOutputRegex('/' . preg_quote('Received SIGTERM, stopping loop' . PHP_EOL, '/') . '$/');
@@ -735,8 +745,10 @@ class AppTest extends TestCase
 
     public function testRunAppWithBusyPortThrows(): void
     {
-        $socket = @stream_socket_server('127.0.0.1:0');
+        $socket = stream_socket_server('127.0.0.1:0');
+        assert(is_resource($socket));
         $addr = stream_socket_get_name($socket, false);
+        assert(is_string($addr));
 
         if (@stream_socket_server($addr) !== false) {
             $this->markTestSkipped('System does not prevent listening on same address twice');

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -38,7 +38,7 @@ use function React\Promise\resolve;
 
 class AppTest extends TestCase
 {
-    public function testConstructWithMiddlewareAssignsGivenMiddleware()
+    public function testConstructWithMiddlewareAssignsGivenMiddleware(): void
     {
         $middleware = function () { };
         $app = new App($middleware);
@@ -64,7 +64,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[3]);
     }
 
-    public function testConstructWithContainerAssignsDefaultHandlersAndContainerForRouteHandlerOnly()
+    public function testConstructWithContainerAssignsDefaultHandlersAndContainerForRouteHandlerOnly(): void
     {
         $accessLogHandler = new AccessLogHandler();
         $errorHandler = new ErrorHandler();
@@ -100,7 +100,7 @@ class AppTest extends TestCase
         $this->assertSame($container, $ref->getValue($routeHandler));
     }
 
-    public function testConstructWithContainerAndMiddlewareClassNameAssignsCallableFromContainerAsMiddleware()
+    public function testConstructWithContainerAndMiddlewareClassNameAssignsCallableFromContainerAsMiddleware(): void
     {
         $middleware = function (ServerRequestInterface $request, callable $next) { };
 
@@ -135,7 +135,7 @@ class AppTest extends TestCase
         $this->assertSame($container, $ref->getValue($routeHandler));
     }
 
-    public function testConstructWithErrorHandlerOnlyAssignsErrorHandlerAfterDefaultAccessLogHandler()
+    public function testConstructWithErrorHandlerOnlyAssignsErrorHandlerAfterDefaultAccessLogHandler(): void
     {
         $errorHandler = new ErrorHandler();
 
@@ -161,7 +161,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
-    public function testConstructWithErrorHandlerClassOnlyAssignsErrorHandlerAfterDefaultAccessLogHandler()
+    public function testConstructWithErrorHandlerClassOnlyAssignsErrorHandlerAfterDefaultAccessLogHandler(): void
     {
         $app = new App(ErrorHandler::class);
 
@@ -185,7 +185,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
-    public function testConstructWithContainerAndErrorHandlerAssignsErrorHandlerAfterDefaultAccessLogHandler()
+    public function testConstructWithContainerAndErrorHandlerAssignsErrorHandlerAfterDefaultAccessLogHandler(): void
     {
         $errorHandler = new ErrorHandler();
 
@@ -211,7 +211,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
-    public function testConstructWithContainerAndErrorHandlerClassAssignsErrorHandlerFromContainerAfterDefaultAccessLogHandler()
+    public function testConstructWithContainerAndErrorHandlerClassAssignsErrorHandlerFromContainerAfterDefaultAccessLogHandler(): void
     {
         $errorHandler = new ErrorHandler();
 
@@ -240,7 +240,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
-    public function testConstructWithMultipleContainersAndErrorHandlerClassAssignsErrorHandlerFromLastContainerBeforeErrorHandlerAfterDefaultAccessLogHandler()
+    public function testConstructWithMultipleContainersAndErrorHandlerClassAssignsErrorHandlerFromLastContainerBeforeErrorHandlerAfterDefaultAccessLogHandler(): void
     {
         $errorHandler = new ErrorHandler();
 
@@ -272,7 +272,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
-    public function testConstructWithMultipleContainersAndMiddlewareAssignsErrorHandlerFromLastContainerBeforeMiddlewareAfterDefaultAccessLogHandler()
+    public function testConstructWithMultipleContainersAndMiddlewareAssignsErrorHandlerFromLastContainerBeforeMiddlewareAfterDefaultAccessLogHandler(): void
     {
         $middleware = function (ServerRequestInterface $request, callable $next) { };
         $errorHandler = new ErrorHandler();
@@ -306,7 +306,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[3]);
     }
 
-    public function testConstructWithMiddlewareAndErrorHandlerAssignsGivenErrorHandlerAfterMiddlewareAndDefaultAccessLogHandlerAndErrorHandlerFirst()
+    public function testConstructWithMiddlewareAndErrorHandlerAssignsGivenErrorHandlerAfterMiddlewareAndDefaultAccessLogHandlerAndErrorHandlerFirst(): void
     {
         $middleware = function (ServerRequestInterface $request, callable $next) { };
         $errorHandler = new ErrorHandler();
@@ -336,7 +336,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[4]);
     }
 
-    public function testConstructWithMultipleContainersAndMiddlewareAndErrorHandlerClassAssignsDefaultErrorHandlerFromLastContainerBeforeMiddlewareAndErrorHandlerFromLastContainerAfterDefaultAccessLogHandler()
+    public function testConstructWithMultipleContainersAndMiddlewareAndErrorHandlerClassAssignsDefaultErrorHandlerFromLastContainerBeforeMiddlewareAndErrorHandlerFromLastContainerAfterDefaultAccessLogHandler(): void
     {
         $middleware = function (ServerRequestInterface $request, callable $next) { };
 
@@ -375,7 +375,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[4]);
     }
 
-    public function testConstructWithAccessLogHandlerAndErrorHandlerAssignsHandlersAsGiven()
+    public function testConstructWithAccessLogHandlerAndErrorHandlerAssignsHandlersAsGiven(): void
     {
         $accessLogHandler = new AccessLogHandler();
         $errorHandler = new ErrorHandler();
@@ -402,7 +402,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
-    public function testConstructWithAccessLogHandlerClassAndErrorHandlerClassAssignsDefaultHandlers()
+    public function testConstructWithAccessLogHandlerClassAndErrorHandlerClassAssignsDefaultHandlers(): void
     {
         $app = new App(AccessLogHandler::class, ErrorHandler::class);
 
@@ -426,7 +426,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
-    public function testConstructWithContainerAndAccessLogHandlerClassAndErrorHandlerClassAssignsHandlersFromContainer()
+    public function testConstructWithContainerAndAccessLogHandlerClassAndErrorHandlerClassAssignsHandlersFromContainer(): void
     {
         $accessLogHandler = new AccessLogHandler();
         $errorHandler = new ErrorHandler();
@@ -457,7 +457,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[2]);
     }
 
-    public function testConstructWithMiddlewareBeforeAccessLogHandlerAndErrorHandlerAssignsDefaultErrorHandlerAsFirstHandlerFollowedByGivenHandlers()
+    public function testConstructWithMiddlewareBeforeAccessLogHandlerAndErrorHandlerAssignsDefaultErrorHandlerAsFirstHandlerFollowedByGivenHandlers(): void
     {
         $middleware = static function (ServerRequestInterface $request, callable $next) { };
         $accessLog = new AccessLogHandler();
@@ -488,7 +488,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[4]);
     }
 
-    public function testConstructWithMultipleContainersAndAccessLogHandlerClassAndErrorHandlerClassAssignsHandlersFromLastContainer()
+    public function testConstructWithMultipleContainersAndAccessLogHandlerClassAndErrorHandlerClassAssignsHandlersFromLastContainer(): void
     {
         $accessLogHandler = new AccessLogHandler();
         $errorHandler = new ErrorHandler();
@@ -523,7 +523,7 @@ class AppTest extends TestCase
     }
 
 
-    public function testConstructWithMultipleContainersAndMiddlewareAssignsDefaultHandlersFromLastContainerBeforeMiddleware()
+    public function testConstructWithMultipleContainersAndMiddlewareAssignsDefaultHandlersFromLastContainerBeforeMiddleware(): void
     {
         $middleware = function (ServerRequestInterface $request, callable $next) { };
 
@@ -561,7 +561,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RouteHandler::class, $handlers[3]);
     }
 
-    public function testConstructWithAccessLogHandlerOnlyThrows()
+    public function testConstructWithAccessLogHandlerOnlyThrows(): void
     {
         $accessLogHandler = new AccessLogHandler();
 
@@ -569,7 +569,7 @@ class AppTest extends TestCase
         new App($accessLogHandler);
     }
 
-    public function testConstructWithAccessLogHandlerFollowedByMiddlewareThrows()
+    public function testConstructWithAccessLogHandlerFollowedByMiddlewareThrows(): void
     {
         $accessLogHandler = new AccessLogHandler();
         $middleware = function (ServerRequestInterface $request, callable $next) { };
@@ -578,7 +578,7 @@ class AppTest extends TestCase
         new App($accessLogHandler, $middleware);
     }
 
-    public function testRunWillReportListeningAddressAndRunLoopWithSocketServer()
+    public function testRunWillReportListeningAddressAndRunLoopWithSocketServer(): void
     {
         $socket = @stream_socket_server('127.0.0.1:8080');
         if ($socket === false) {
@@ -603,7 +603,7 @@ class AppTest extends TestCase
         $app->run();
     }
 
-    public function testRunWillReportListeningAddressFromContainerEnvironmentAndRunLoopWithSocketServer()
+    public function testRunWillReportListeningAddressFromContainerEnvironmentAndRunLoopWithSocketServer(): void
     {
         $socket = @stream_socket_server('127.0.0.1:0');
         $addr = stream_socket_get_name($socket, false);
@@ -630,7 +630,7 @@ class AppTest extends TestCase
         $app->run();
     }
 
-    public function testRunWillReportListeningAddressFromContainerEnvironmentWithRandomPortAndRunLoopWithSocketServer()
+    public function testRunWillReportListeningAddressFromContainerEnvironmentWithRandomPortAndRunLoopWithSocketServer(): void
     {
         $container = new Container([
             'X_LISTEN' => '127.0.0.1:0'
@@ -653,7 +653,7 @@ class AppTest extends TestCase
         $app->run();
     }
 
-    public function testRunWillRestartLoopUntilSocketIsClosed()
+    public function testRunWillRestartLoopUntilSocketIsClosed(): void
     {
         $container = new Container([
             'X_LISTEN' => '127.0.0.1:0'
@@ -684,7 +684,7 @@ class AppTest extends TestCase
      * @requires function pcntl_signal
      * @requires function posix_kill
      */
-    public function testRunWillStopWhenReceivingSigint()
+    public function testRunWillStopWhenReceivingSigint(): void
     {
         $container = new Container([
             'X_LISTEN' => '127.0.0.1:0'
@@ -704,7 +704,7 @@ class AppTest extends TestCase
      * @requires function pcntl_signal
      * @requires function posix_kill
      */
-    public function testRunWillStopWhenReceivingSigterm()
+    public function testRunWillStopWhenReceivingSigterm(): void
     {
         $container = new Container([
             'X_LISTEN' => '127.0.0.1:0'
@@ -720,7 +720,7 @@ class AppTest extends TestCase
         $app->run();
     }
 
-    public function testRunAppWithEmptyAddressThrows()
+    public function testRunAppWithEmptyAddressThrows(): void
     {
         $container = new Container([
             'X_LISTEN' => ''
@@ -733,7 +733,7 @@ class AppTest extends TestCase
         $app->run();
     }
 
-    public function testRunAppWithBusyPortThrows()
+    public function testRunAppWithBusyPortThrows(): void
     {
         $socket = @stream_socket_server('127.0.0.1:0');
         $addr = stream_socket_get_name($socket, false);
@@ -753,7 +753,7 @@ class AppTest extends TestCase
         $app->run();
     }
 
-    public function testRunOnceWillCreateRequestFromSapiThenRouteRequestAndThenSendResponseFromHandler()
+    public function testRunOnceWillCreateRequestFromSapiThenRouteRequestAndThenSendResponseFromHandler(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -779,7 +779,7 @@ class AppTest extends TestCase
         $ref->invoke($app);
     }
 
-    public function testRunOnceWillCreateRequestFromSapiThenRouteRequestAndThenSendResponseFromDeferredHandler()
+    public function testRunOnceWillCreateRequestFromSapiThenRouteRequestAndThenSendResponseFromDeferredHandler(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -805,7 +805,7 @@ class AppTest extends TestCase
         $ref->invoke($app);
     }
 
-    public function testGetMethodAddsGetRouteOnRouter()
+    public function testGetMethodAddsGetRouteOnRouter(): void
     {
         $app = new App();
 
@@ -819,7 +819,7 @@ class AppTest extends TestCase
         $app->get('/', function () { });
     }
 
-    public function testHeadMethodAddsHeadRouteOnRouter()
+    public function testHeadMethodAddsHeadRouteOnRouter(): void
     {
         $app = new App();
 
@@ -833,7 +833,7 @@ class AppTest extends TestCase
         $app->head('/', function () { });
     }
 
-    public function testPostMethodAddsPostRouteOnRouter()
+    public function testPostMethodAddsPostRouteOnRouter(): void
     {
         $app = new App();
 
@@ -847,7 +847,7 @@ class AppTest extends TestCase
         $app->post('/', function () { });
     }
 
-    public function testPutMethodAddsPutRouteOnRouter()
+    public function testPutMethodAddsPutRouteOnRouter(): void
     {
         $app = new App();
 
@@ -861,7 +861,7 @@ class AppTest extends TestCase
         $app->put('/', function () { });
     }
 
-    public function testPatchMethodAddsPatchRouteOnRouter()
+    public function testPatchMethodAddsPatchRouteOnRouter(): void
     {
         $app = new App();
 
@@ -875,7 +875,7 @@ class AppTest extends TestCase
         $app->patch('/', function () { });
     }
 
-    public function testDeleteMethodAddsDeleteRouteOnRouter()
+    public function testDeleteMethodAddsDeleteRouteOnRouter(): void
     {
         $app = new App();
 
@@ -889,7 +889,7 @@ class AppTest extends TestCase
         $app->delete('/', function () { });
     }
 
-    public function testOptionsMethodAddsOptionsRouteOnRouter()
+    public function testOptionsMethodAddsOptionsRouteOnRouter(): void
     {
         $app = new App();
 
@@ -903,7 +903,7 @@ class AppTest extends TestCase
         $app->options('/', function () { });
     }
 
-    public function testAnyMethodAddsRouteOnRouter()
+    public function testAnyMethodAddsRouteOnRouter(): void
     {
         $app = new App();
 
@@ -917,7 +917,7 @@ class AppTest extends TestCase
         $app->any('/', function () { });
     }
 
-    public function testMapMethodAddsRouteOnRouter()
+    public function testMapMethodAddsRouteOnRouter(): void
     {
         $app = new App();
 
@@ -931,7 +931,7 @@ class AppTest extends TestCase
         $app->map(['GET', 'POST'], '/', function () { });
     }
 
-    public function testGetWithAccessLogHandlerAsMiddlewareThrows()
+    public function testGetWithAccessLogHandlerAsMiddlewareThrows(): void
     {
         $app = new App();
 
@@ -939,7 +939,7 @@ class AppTest extends TestCase
         $app->get('/', new AccessLogHandler(), function () { });
     }
 
-    public function testGetWithAccessLogHandlerClassAsMiddlewareThrows()
+    public function testGetWithAccessLogHandlerClassAsMiddlewareThrows(): void
     {
         $app = new App();
 
@@ -947,7 +947,7 @@ class AppTest extends TestCase
         $app->get('/', AccessLogHandler::class, function () { });
     }
 
-    public function testRedirectMethodAddsAnyRouteOnRouterWhichWhenInvokedReturnsRedirectResponseWithTargetLocation()
+    public function testRedirectMethodAddsAnyRouteOnRouterWhichWhenInvokedReturnsRedirectResponseWithTargetLocation(): void
     {
         $app = new App();
 
@@ -979,7 +979,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Redirecting to <a href=\"/users\"><code>/users</code></a>...</p>\n", (string) $response->getBody());
     }
 
-    public function testRedirectMethodWithCustomRedirectCodeAddsAnyRouteOnRouterWhichWhenInvokedReturnsRedirectResponseWithCustomRedirectCode()
+    public function testRedirectMethodWithCustomRedirectCodeAddsAnyRouteOnRouterWhichWhenInvokedReturnsRedirectResponseWithCustomRedirectCode(): void
     {
         $app = new App();
 
@@ -1011,7 +1011,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Redirecting to <a href=\"/users\"><code>/users</code></a>...</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithProxyRequestReturnsResponseWithMessageThatProxyRequestsAreNotAllowed()
+    public function testHandleRequestWithProxyRequestReturnsResponseWithMessageThatProxyRequestsAreNotAllowed(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1033,7 +1033,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Please check your settings and retry.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithUnknownRouteReturnsResponseWithFileNotFoundMessage()
+    public function testHandleRequestWithUnknownRouteReturnsResponseWithFileNotFoundMessage(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1054,7 +1054,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Please check the URL in the address bar and try again.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithInvalidRequestMethodReturnsResponseWithSingleMethodNotAllowedMessage()
+    public function testHandleRequestWithInvalidRequestMethodReturnsResponseWithSingleMethodNotAllowedMessage(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1078,7 +1078,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Please check the URL in the address bar and try again with <code>GET</code> request.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithInvalidRequestMethodReturnsResponseWithMultipleMethodNotAllowedMessage()
+    public function testHandleRequestWithInvalidRequestMethodReturnsResponseWithMultipleMethodNotAllowedMessage(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1104,7 +1104,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Please check the URL in the address bar and try again with <code>GET</code>/<code>HEAD</code>/<code>POST</code> request.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsResponseFromMatchingRouteHandler()
+    public function testHandleRequestWithMatchingRouteReturnsResponseFromMatchingRouteHandler(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1132,7 +1132,7 @@ class AppTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithOptionsAsteriskRequestReturnsResponseFromMatchingEmptyRouteHandler()
+    public function testHandleRequestWithOptionsAsteriskRequestReturnsResponseFromMatchingEmptyRouteHandler(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1161,7 +1161,7 @@ class AppTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithResponseWhenHandlerReturnsPromiseWhichFulfillsWithResponse()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithResponseWhenHandlerReturnsPromiseWhichFulfillsWithResponse(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1197,7 +1197,7 @@ class AppTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPendingPromiseWhenHandlerReturnsPendingPromise()
+    public function testHandleRequestWithMatchingRouteReturnsPendingPromiseWhenHandlerReturnsPendingPromise(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1225,7 +1225,7 @@ class AppTest extends TestCase
         $this->assertFalse($resolved);
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsResponseWhenHandlerReturnsCoroutineWhichReturnsResponseWithoutYielding()
+    public function testHandleRequestWithMatchingRouteReturnsResponseWhenHandlerReturnsCoroutineWhichReturnsResponseWithoutYielding(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1257,7 +1257,7 @@ class AppTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithResponseWhenHandlerReturnsCoroutineWhichReturnsResponseAfterYieldingResolvedPromise()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithResponseWhenHandlerReturnsCoroutineWhichReturnsResponseAfterYieldingResolvedPromise(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1295,7 +1295,7 @@ class AppTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithResponseWhenHandlerReturnsCoroutineWhichReturnsResponseAfterCatchingExceptionFromYieldingRejectedPromise()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithResponseWhenHandlerReturnsCoroutineWhichReturnsResponseAfterCatchingExceptionFromYieldingRejectedPromise(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1338,7 +1338,7 @@ class AppTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPendingPromiseWhenHandlerReturnsCoroutineThatYieldsPendingPromise()
+    public function testHandleRequestWithMatchingRouteReturnsPendingPromiseWhenHandlerReturnsCoroutineThatYieldsPendingPromise(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1366,7 +1366,7 @@ class AppTest extends TestCase
         $this->assertFalse($resolved);
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsResponseWhenHandlerReturnsResponseAfterAwaitingPromiseResolvingWithResponse()
+    public function testHandleRequestWithMatchingRouteReturnsResponseWhenHandlerReturnsResponseAfterAwaitingPromiseResolvingWithResponse(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1394,7 +1394,7 @@ class AppTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseResolvingWithResponseWhenHandlerReturnsResponseAfterAwaitingPromiseResolvingWithResponse()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseResolvingWithResponseWhenHandlerReturnsResponseAfterAwaitingPromiseResolvingWithResponse(): void
     {
         if (PHP_VERSION_ID < 80100 || !function_exists('React\Async\async')) {
             $this->markTestSkipped('Requires PHP 8.1+ with react/async 4+');
@@ -1440,7 +1440,7 @@ class AppTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteAndRouteVariablesReturnsResponseFromHandlerWithRouteVariablesAssignedAsRequestAttributes()
+    public function testHandleRequestWithMatchingRouteAndRouteVariablesReturnsResponseFromHandlerWithRouteVariablesAssignedAsRequestAttributes(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1470,7 +1470,7 @@ class AppTest extends TestCase
         $this->assertEquals("Hello alice\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerThrowsException()
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerThrowsException(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1497,7 +1497,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>Foo</code> in <code title=\"See " . __FILE__ . " line $line\">AppTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsPromiseWhichRejectsWithException()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsPromiseWhichRejectsWithException(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1532,7 +1532,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>Foo</code> in <code title=\"See " . __FILE__ . " line $line\">AppTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsPromiseWhichRejectsWithNull()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsPromiseWhichRejectsWithNull(): void
     {
         if (method_exists(PromiseInterface::class, 'catch')) {
             $this->markTestSkipped('Only supported for legacy Promise v2, Promise v3 always rejects with Throwable');
@@ -1570,7 +1570,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got <code>React\Promise\RejectedPromise</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichYieldsRejectedPromise()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichYieldsRejectedPromise(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1605,7 +1605,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>Foo</code> in <code title=\"See " . __FILE__ . " line $line\">AppTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichThrowsExceptionWithoutYielding()
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichThrowsExceptionWithoutYielding(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1635,7 +1635,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>Foo</code> in <code title=\"See " . __FILE__ . " line $line\">AppTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichThrowsExceptionAfterYielding()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichThrowsExceptionAfterYielding(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1671,7 +1671,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>Foo</code> in <code title=\"See " . __FILE__ . " line $line\">AppTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerThrowsAfterAwaitingPromiseRejectingWithException()
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerThrowsAfterAwaitingPromiseRejectingWithException(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1698,7 +1698,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>Foo</code> in <code title=\"See " . __FILE__ . " line $line\">AppTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerThrowsAfterAwaitingPromiseRejectingWithException()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerThrowsAfterAwaitingPromiseRejectingWithException(): void
     {
         if (PHP_VERSION_ID < 80100 || !function_exists('React\Async\async')) {
             $this->markTestSkipped('Requires PHP 8.1+ with react/async 4+');
@@ -1745,7 +1745,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>Foo</code> in <code title=\"See " . __FILE__ . " line $line\">AppTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichReturnsNull()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichReturnsNull(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1780,7 +1780,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got <code>null</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichYieldsNullImmediately()
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerReturnsCoroutineWhichYieldsNullImmediately(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1807,7 +1807,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to yield <code>React\Promise\PromiseInterface</code> but got <code>null</code> near or before <code title=\"See " . __FILE__ . " line $line\">AppTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerReturnsWrongValue()
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerReturnsWrongValue(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1833,7 +1833,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got <code>null</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerClassDoesNotExist()
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerClassDoesNotExist(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1857,7 +1857,7 @@ class AppTest extends TestCase
         $this->assertStringMatchesFormat("%a<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>BadMethodCallException</code> with message <code>Request handler class UnknownClass not found</code> in <code title=\"See %s\">Container.php:%d</code>.</p>\n%a", (string) $response->getBody());
     }
 
-    public function provideInvalidClasses()
+    public function provideInvalidClasses(): \Generator
     {
         yield [
             InvalidConstructorPrivate::class,
@@ -1924,7 +1924,7 @@ class AppTest extends TestCase
      * @param class-string $class
      * @param string $error
      */
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerClassIsInvalid(string $class, string $error)
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerClassIsInvalid(string $class, string $error): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -1948,13 +1948,13 @@ class AppTest extends TestCase
         $this->assertStringMatchesFormat("%a<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>BadMethodCallException</code> with message <code>Request handler class " . $class . " failed to load: $error</code> in <code title=\"See %s\">Container.php:%d</code>.</p>\n%a", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerClassRequiresUnexpectedCallableParameter()
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerClassRequiresUnexpectedCallableParameter(): void
     {
         $app = $this->createAppWithoutLogger();
 
         $line = __LINE__ + 2;
         $controller = new class {
-            public function __invoke(int $value) { }
+            public function __invoke(int $value): void { }
         };
 
         $app->get('/users', get_class($controller));
@@ -1977,7 +1977,7 @@ class AppTest extends TestCase
         $this->assertStringMatchesFormat("%a<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>TypeError</code> with message <code>%s</code> in <code title=\"See " . __FILE__ . " line $line\">AppTest.php:$line</code>.</p>\n%a", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerClassHasNoInvokeMethod()
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerClassHasNoInvokeMethod(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -2003,7 +2003,7 @@ class AppTest extends TestCase
         $this->assertStringMatchesFormat("%a<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>BadMethodCallException</code> with message <code>Request handler class %s has no public __invoke() method</code> in <code title=\"See %s\">Container.php:%d</code>.</p>\n%a", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsPromiseWhichFulfillsWithWrongValue()
+    public function testHandleRequestWithMatchingRouteReturnsPromiseWhichFulfillsWithInternalServerErrorResponseWhenHandlerReturnsPromiseWhichFulfillsWithWrongValue(): void
     {
         $app = $this->createAppWithoutLogger();
 
@@ -2037,7 +2037,7 @@ class AppTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got <code>null</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerReturnsWrongValueAfterYielding()
+    public function testHandleRequestWithMatchingRouteReturnsInternalServerErrorResponseWhenHandlerReturnsWrongValueAfterYielding(): void
     {
         $app = $this->createAppWithoutLogger();
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -566,7 +566,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
-    /** @return list<list<mixed>> */
+    /** @return list<list<\stdClass|string|null>> */
     public function provideMixedValue(): array
     {
         return [
@@ -587,7 +587,7 @@ class ContainerTest extends TestCase
 
     /**
      * @dataProvider provideMixedValue
-     * @param mixed $value
+     * @param \stdClass|string|null $value
      */
     public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariable($value, string $json): void
     {
@@ -626,7 +626,7 @@ class ContainerTest extends TestCase
 
     /**
      * @dataProvider provideMixedValue
-     * @param mixed $value
+     * @param \stdClass|string|null $value
      */
     public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariableWithFactory($value, string $json): void
     {
@@ -668,7 +668,7 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      * @dataProvider provideMixedValue
-     * @param mixed $value
+     * @param \stdClass|string|null $value
      */
     public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresMixedContainerVariable($value, string $json): void
     {

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -51,7 +51,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -83,7 +83,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -113,7 +113,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -146,7 +146,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -176,7 +176,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -206,7 +206,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -239,7 +239,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -270,7 +270,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -301,7 +301,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -331,7 +331,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -365,7 +365,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -405,7 +405,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -441,7 +441,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -480,7 +480,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (\stdClass $dto) {
-                return new Response(200, [], json_encode($dto));
+                return new Response(200, [], (string) json_encode($dto));
             },
             \stdClass::class => function () { return (object)['name' => 'Alice']; }
         ]);
@@ -515,7 +515,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (\stdClass $data) {
-                return new Response(200, [], json_encode($data));
+                return new Response(200, [], (string) json_encode($data));
             },
             'data' => (object) ['name' => 'Alice']
         ]);
@@ -550,7 +550,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (\stdClass $data) {
-                return new Response(200, [], json_encode($data));
+                return new Response(200, [], (string) json_encode($data));
             },
             'data' => function () {
                 return (object) ['name' => 'Alice'];
@@ -610,7 +610,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function ($data) {
-                return new Response(200, [], json_encode($data));
+                return new Response(200, [], (string) json_encode($data));
             },
             'data' => $value
         ]);
@@ -649,7 +649,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function ($data) {
-                return new Response(200, [], json_encode($data));
+                return new Response(200, [], (string) json_encode($data));
             },
             'data' => function () use ($value) {
                 return $value;
@@ -691,7 +691,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (mixed $data) {
-                return new Response(200, [], json_encode($data));
+                return new Response(200, [], (string) json_encode($data));
             },
             'data' => $value
         ]);
@@ -731,7 +731,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (mixed $data) {
-                return new Response(200, [], json_encode($data));
+                return new Response(200, [], (string) json_encode($data));
             },
             'data' => function () use ($value) {
                 return $value;
@@ -768,7 +768,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function ($data = 42) {
-                return new Response(200, [], json_encode($data));
+                return new Response(200, [], (string) json_encode($data));
             },
             'data' => null
         ]);
@@ -805,7 +805,7 @@ class ContainerTest extends TestCase
         };
 
         $fn = null;
-        $fn = #[PHP8] fn(mixed $data = 42) => new Response(200, [], json_encode($data)); // @phpstan-ignore-line
+        $fn = #[PHP8] fn(mixed $data = 42) => new Response(200, [], (string) json_encode($data)); // @phpstan-ignore-line
         $container = new Container([
             ResponseInterface::class => $fn,
             'data' => null
@@ -841,7 +841,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (?\stdClass $user, ?\stdClass $data) {
-                return new Response(200, [], json_encode(['user' => $user, 'data' => $data]));
+                return new Response(200, [], (string) json_encode(['user' => $user, 'data' => $data]));
             },
             'user' => (object) []
         ]);
@@ -876,7 +876,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (?\stdClass $user, ?\stdClass $data) {
-                return new Response(200, [], json_encode(['user' => $user, 'data' => $data]));
+                return new Response(200, [], (string) json_encode(['user' => $user, 'data' => $data]));
             },
             'user' => function (): ?\stdClass { // @phpstan-ignore-line
                 return (object) [];
@@ -913,7 +913,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (string $name = 'Alice', int $age = 0) {
-                return new Response(200, [], json_encode(['name' => $name, 'age' => $age]));
+                return new Response(200, [], (string) json_encode(['name' => $name, 'age' => $age]));
             },
             'age' => 42
         ]);
@@ -942,7 +942,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -980,7 +980,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1017,7 +1017,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1060,7 +1060,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (string $FOO) {
-                return new Response(200, [], json_encode($FOO));
+                return new Response(200, [], (string) json_encode($FOO));
             }
         ]);
 
@@ -1097,7 +1097,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (string $address) {
-                return new Response(200, [], json_encode($address));
+                return new Response(200, [], (string) json_encode($address));
             },
             'address' => function (string $FOO) {
                 return 'http://' . $FOO;
@@ -1137,7 +1137,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (?string $FOO) {
-                return new Response(200, [], json_encode($FOO));
+                return new Response(200, [], (string) json_encode($FOO));
             }
         ]);
 
@@ -1174,7 +1174,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (?string $FOO) {
-                return new Response(200, [], json_encode($FOO));
+                return new Response(200, [], (string) json_encode($FOO));
             }
         ]);
 
@@ -1208,7 +1208,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function ($FOO) {
-                return new Response(200, [], json_encode($FOO));
+                return new Response(200, [], (string) json_encode($FOO));
             }
         ]);
 
@@ -1248,7 +1248,7 @@ class ContainerTest extends TestCase
 
         $container = new Container([
             ResponseInterface::class => function (mixed $FOO) {
-                return new Response(200, [], json_encode($FOO));
+                return new Response(200, [], (string) json_encode($FOO));
             }
         ]);
 
@@ -1279,7 +1279,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1311,7 +1311,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1343,7 +1343,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1377,7 +1377,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1412,7 +1412,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1445,7 +1445,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1478,7 +1478,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1511,7 +1511,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1544,7 +1544,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1577,7 +1577,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1607,7 +1607,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1637,7 +1637,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1667,7 +1667,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1697,7 +1697,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1727,7 +1727,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1757,7 +1757,7 @@ class ContainerTest extends TestCase
 
             public function __invoke(ServerRequestInterface $request): Response
             {
-                return new Response(200, [], json_encode($this->data));
+                return new Response(200, [], (string) json_encode($this->data));
             }
         };
 
@@ -1787,7 +1787,7 @@ class ContainerTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Map for file contains unexpected resource');
 
-        new Container([
+        new Container([ // @phpstan-ignore-line
             'file' => tmpfile()
         ]);
     }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -15,12 +15,12 @@ use React\Http\Message\ServerRequest;
 
 class ContainerTest extends TestCase
 {
-    public function testCallableReturnsCallableForClassNameViaAutowiring()
+    public function testCallableReturnsCallableForClassNameViaAutowiring(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class {
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200);
             }
@@ -36,11 +36,12 @@ class ContainerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testCallableReturnsCallableForClassNameViaAutowiringWithConfigurationForDependency()
+    public function testCallableReturnsCallableForClassNameViaAutowiringWithConfigurationForDependency(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -48,7 +49,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -67,11 +68,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForNullableClassViaAutowiringWillDefaultToNullValue()
+    public function testCallableReturnsCallableForNullableClassViaAutowiringWillDefaultToNullValue(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var ?\stdClass */
             private $data;
 
             public function __construct(?\stdClass $data)
@@ -79,7 +81,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -96,11 +98,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('null', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForNullableClassViaContainerConfiguration()
+    public function testCallableReturnsCallableForNullableClassViaContainerConfiguration(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var ?\stdClass */
             private $data;
 
             public function __construct(?\stdClass $data)
@@ -108,7 +111,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -130,17 +133,18 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      */
-    public function testCallableReturnsCallableForUnionWithNullViaAutowiringWillDefaultToNullValue()
+    public function testCallableReturnsCallableForUnionWithNullViaAutowiringWillDefaultToNullValue(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         // @phpstan-ignore-next-line for PHP < 8
         $controller = new class(null) {
+            /** @var mixed */
             private $data = false;
 
             #[PHP8] public function __construct(string|int|null $data) { $this->data = $data; } // @phpstan-ignore-line
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -157,11 +161,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('null', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassWithNullDefaultViaAutowiringWillDefaultToNullValue()
+    public function testCallableReturnsCallableForClassWithNullDefaultViaAutowiringWillDefaultToNullValue(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(null) {
+            /** @var \stdClass|null|false */
             private $data = false;
 
             public function __construct(\stdClass $data = null)
@@ -169,7 +174,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -186,11 +191,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('null', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassWithNullDefaultViaContainerConfiguration()
+    public function testCallableReturnsCallableForClassWithNullDefaultViaContainerConfiguration(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(null) {
+            /** @var \stdClass|null|false */
             private $data = false;
 
             public function __construct(\stdClass $data = null)
@@ -198,7 +204,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -220,17 +226,18 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      */
-    public function testCallableReturnsCallableForUnionWithIntDefaultValueViaAutowiringWillDefaultToIntValue()
+    public function testCallableReturnsCallableForUnionWithIntDefaultValueViaAutowiringWillDefaultToIntValue(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         // @phpstan-ignore-next-line for PHP < 8
         $controller = new class(null) {
+            /** @var string|int|null|false */
             private $data = false;
 
             #[PHP8] public function __construct(string|int|null $data = 42) { $this->data = $data; } // @phpstan-ignore-line
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -247,19 +254,21 @@ class ContainerTest extends TestCase
         $this->assertEquals('42', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForUntypedWithStringDefaultViaAutowiringWillDefaultToStringValue()
+    public function testCallableReturnsCallableForUntypedWithStringDefaultViaAutowiringWillDefaultToStringValue(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(null) {
+            /** @var mixed */
             private $data = false;
 
+            /** @param mixed $data */
             public function __construct($data = 'empty')
             {
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -279,17 +288,18 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      */
-    public function testCallableReturnsCallableForMixedWithStringDefaultViaAutowiringWillDefaultToStringValue()
+    public function testCallableReturnsCallableForMixedWithStringDefaultViaAutowiringWillDefaultToStringValue(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         // @phpstan-ignore-next-line for PHP < 8
         $controller = new class(null) {
+            /** @var mixed */
             private $data = false;
 
             #[PHP8] public function __construct(mixed $data = 'empty') { $this->data = $data; } // @phpstan-ignore-line
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -306,11 +316,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('"empty"', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameViaAutowiringWithFactoryFunctionForDependency()
+    public function testCallableReturnsCallableForClassNameViaAutowiringWithFactoryFunctionForDependency(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -318,7 +329,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -339,11 +350,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
-    public function testCallableTwiceReturnsCallableForClassNameViaAutowiringWithFactoryFunctionForDependencyWillCallFactoryOnlyOnce()
+    public function testCallableTwiceReturnsCallableForClassNameViaAutowiringWithFactoryFunctionForDependencyWillCallFactoryOnlyOnce(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -351,7 +363,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -375,7 +387,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"num":1}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedToSubclassExplicitly()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedToSubclassExplicitly(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -383,6 +395,7 @@ class ContainerTest extends TestCase
         $dto->name = 'Alice';
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -390,7 +403,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -410,7 +423,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedToSubclassFromFactory()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedToSubclassFromFactory(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -418,6 +431,7 @@ class ContainerTest extends TestCase
         $dto->name = 'Alice';
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -425,7 +439,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -445,11 +459,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresOtherClassWithFactory()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresOtherClassWithFactory(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -457,7 +472,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -479,11 +494,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresContainerVariable()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresContainerVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -491,7 +507,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -513,11 +529,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresContainerVariableWithFactory()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresContainerVariableWithFactory(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -525,7 +542,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -549,7 +566,8 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
-    public function provideMixedValue()
+    /** @return list<list<mixed>> */
+    public function provideMixedValue(): array
     {
         return [
             [
@@ -569,12 +587,14 @@ class ContainerTest extends TestCase
 
     /**
      * @dataProvider provideMixedValue
+     * @param mixed $value
      */
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariable($value, string $json)
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariable($value, string $json): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -582,7 +602,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -606,12 +626,14 @@ class ContainerTest extends TestCase
 
     /**
      * @dataProvider provideMixedValue
+     * @param mixed $value
      */
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariableWithFactory($value, string $json)
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariableWithFactory($value, string $json): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -619,7 +641,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -646,12 +668,14 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      * @dataProvider provideMixedValue
+     * @param mixed $value
      */
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresMixedContainerVariable($value, string $json)
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresMixedContainerVariable($value, string $json): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -659,7 +683,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -684,12 +708,14 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      * @dataProvider provideMixedValue
+     * @param mixed $value
      */
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresMixedContainerVariableWithFactory($value, string $json)
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresMixedContainerVariableWithFactory($value, string $json): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -697,7 +723,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -721,11 +747,12 @@ class ContainerTest extends TestCase
         $this->assertEquals($json, (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariableWithIntDefaultAssignExplicitNullValue()
+    public function testCallableReturnsCallableForClassWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariableWithIntDefaultAssignExplicitNullValue(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -733,7 +760,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -758,11 +785,12 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      */
-    public function testCallableReturnsCallableForClassWithDependencyMappedWithFactoryThatRequiresMixedContainerVariableWithIntDefaultAssignExplicitNullValue()
+    public function testCallableReturnsCallableForClassWithDependencyMappedWithFactoryThatRequiresMixedContainerVariableWithIntDefaultAssignExplicitNullValue(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -770,7 +798,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -792,11 +820,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('null', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableContainerVariables()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableContainerVariables(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -804,7 +833,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -826,11 +855,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"user":{},"data":null}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableContainerVariablesWithFactory()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableContainerVariablesWithFactory(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -838,7 +868,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -862,11 +892,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"user":{},"data":null}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresContainerVariablesWithDefaultValues()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresContainerVariablesWithDefaultValues(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -874,7 +905,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -896,11 +927,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice","age":42}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresScalarVariables()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresScalarVariables(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -908,7 +940,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -933,11 +965,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice","age":42,"admin":true,"percent":0.5}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameMappedFromFactoryWithScalarVariablesMappedFromFactory()
+    public function testCallableReturnsCallableForClassNameMappedFromFactoryWithScalarVariablesMappedFromFactory(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -945,7 +978,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -969,11 +1002,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice","age":42,"admin":true,"percent":0.5}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameReferencingVariableMappedFromFactoryReferencingVariable()
+    public function testCallableReturnsCallableForClassNameReferencingVariableMappedFromFactoryReferencingVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -981,7 +1015,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1005,11 +1039,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"ADMIN"}', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresStringEnvironmentVariable()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresStringEnvironmentVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -1017,7 +1052,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -1041,11 +1076,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('"bar"', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresStringMappedFromFactoryThatRequiresStringEnvironmentVariable()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresStringMappedFromFactoryThatRequiresStringEnvironmentVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -1053,7 +1089,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -1080,11 +1116,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('"http:\/\/bar"', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableStringEnvironmentVariable()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableStringEnvironmentVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -1092,7 +1129,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -1116,11 +1153,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('"bar"', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableStringEnvironmentVariableAssignsNull()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresNullableStringEnvironmentVariableAssignsNull(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -1128,7 +1166,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -1149,11 +1187,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('null', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedEnvironmentVariable()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedEnvironmentVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -1161,7 +1200,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -1188,11 +1227,12 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      */
-    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresMixedEnvironmentVariable()
+    public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresMixedEnvironmentVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response()) {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -1200,7 +1240,7 @@ class ContainerTest extends TestCase
                 $this->response = $response;
             }
 
-            public function __invoke()
+            public function __invoke(): ResponseInterface
             {
                 return $this->response;
             }
@@ -1224,11 +1264,12 @@ class ContainerTest extends TestCase
         $this->assertEquals('"bar"', (string) $response->getBody());
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesUnknownVariable()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesUnknownVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1236,7 +1277,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1255,11 +1296,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesRecursiveVariable()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesRecursiveVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1267,7 +1309,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1286,11 +1328,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesStringVariableMappedWithUnexpectedObjectType()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesStringVariableMappedWithUnexpectedObjectType(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class('') {
+            /** @var string */
             private $data;
 
             public function __construct(string $stdClass)
@@ -1298,7 +1341,7 @@ class ContainerTest extends TestCase
                 $this->data = $stdClass;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1319,11 +1362,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesVariableMappedFromFactoryWithUnexpectedReturnType()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesVariableMappedFromFactoryWithUnexpectedReturnType(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1331,7 +1375,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1353,11 +1397,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesObjectVariableMappedFromFactoryWithReturnsUnexpectedInteger()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesObjectVariableMappedFromFactoryWithReturnsUnexpectedInteger(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1365,7 +1410,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1385,11 +1430,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesStringVariableMappedFromFactoryWithReturnsUnexpectedInteger()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesStringVariableMappedFromFactoryWithReturnsUnexpectedInteger(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1397,7 +1443,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1417,11 +1463,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesIntVariableMappedFromFactoryWithReturnsUnexpectedString()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesIntVariableMappedFromFactoryWithReturnsUnexpectedString(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1429,7 +1476,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1449,11 +1496,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesFloatVariableMappedFromFactoryWithReturnsUnexpectedString()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesFloatVariableMappedFromFactoryWithReturnsUnexpectedString(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1461,7 +1509,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1481,11 +1529,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesBoolVariableMappedFromFactoryWithReturnsUnexpectedString()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesBoolVariableMappedFromFactoryWithReturnsUnexpectedString(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1493,7 +1542,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1513,11 +1562,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesClassNameButGetsStringVariable()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesClassNameButGetsStringVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1525,7 +1575,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1542,11 +1592,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesNullableClassButGetsStringVariable()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesNullableClassButGetsStringVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var ?\stdClass */
             private $data;
 
             public function __construct(?\stdClass $data)
@@ -1554,7 +1605,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1571,11 +1622,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesClassNameButGetsIntVariable()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesClassNameButGetsIntVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1583,7 +1635,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1600,11 +1652,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesClassNameButGetsNullVariable()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesClassNameButGetsNullVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1612,7 +1665,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1629,11 +1682,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesNullableClassNameButGetsNullVariable()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesNullableClassNameButGetsNullVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var ?\stdClass */
             private $data;
 
             public function __construct(?\stdClass $data)
@@ -1641,7 +1695,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1658,11 +1712,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesClassMappedToUnexpectedObject()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesClassMappedToUnexpectedObject(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new \stdClass()) {
+            /** @var \stdClass */
             private $data;
 
             public function __construct(\stdClass $data)
@@ -1670,7 +1725,7 @@ class ContainerTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1687,11 +1742,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenConstructorWithoutFactoryFunctionReferencesStringVariable()
+    public function testCallableReturnsCallableThatThrowsWhenConstructorWithoutFactoryFunctionReferencesStringVariable(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class('Alice') {
+            /** @var string */
             private $data;
 
             public function __construct(string $name)
@@ -1699,7 +1755,7 @@ class ContainerTest extends TestCase
                 $this->data = $name;
             }
 
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200, [], json_encode($this->data));
             }
@@ -1716,7 +1772,7 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCtorThrowsWhenMapContainsInvalidArray()
+    public function testCtorThrowsWhenMapContainsInvalidArray(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Map for all contains unexpected array');
@@ -1726,7 +1782,7 @@ class ContainerTest extends TestCase
         ]);
     }
 
-    public function testCtorThrowsWhenMapContainsInvalidResource()
+    public function testCtorThrowsWhenMapContainsInvalidResource(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Map for file contains unexpected resource');
@@ -1736,7 +1792,7 @@ class ContainerTest extends TestCase
         ]);
     }
 
-    public function testCtorThrowsWhenMapForClassContainsInvalidObject()
+    public function testCtorThrowsWhenMapForClassContainsInvalidObject(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Map for Psr\Http\Message\ResponseInterface contains unexpected stdClass');
@@ -1746,7 +1802,7 @@ class ContainerTest extends TestCase
         ]);
     }
 
-    public function testCtorThrowsWhenMapForClassContainsInvalidNull()
+    public function testCtorThrowsWhenMapForClassContainsInvalidNull(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Map for Psr\Http\Message\ResponseInterface contains unexpected NULL');
@@ -1756,7 +1812,7 @@ class ContainerTest extends TestCase
         ]);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReturnsInvalidClassName()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReturnsInvalidClassName(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1771,7 +1827,7 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReturnsInvalidInteger()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReturnsInvalidInteger(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1786,7 +1842,7 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenMapReferencesClassNameThatDoesNotMatchType()
+    public function testCallableReturnsCallableThatThrowsWhenMapReferencesClassNameThatDoesNotMatchType(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1801,7 +1857,7 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReturnsClassNameThatDoesNotMatchType()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReturnsClassNameThatDoesNotMatchType(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1816,7 +1872,7 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryRequiresInvalidClassName()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryRequiresInvalidClassName(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1831,7 +1887,7 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryRequiresUntypedArgument()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryRequiresUntypedArgument(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1849,7 +1905,7 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      */
-    public function testCallableReturnsCallableThatThrowsWhenFactoryRequiresUndefinedMixedArgument()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryRequiresUndefinedMixedArgument(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1864,7 +1920,7 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryRequiresRecursiveClass()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryRequiresRecursiveClass(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1879,7 +1935,7 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryIsRecursive()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryIsRecursive(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1894,7 +1950,7 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryIsRecursiveClassName()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryIsRecursiveClassName(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1911,12 +1967,12 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableForClassNameViaPsrContainer()
+    public function testCallableReturnsCallableForClassNameViaPsrContainer(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class {
-            public function __invoke(ServerRequestInterface $request)
+            public function __invoke(ServerRequestInterface $request): Response
             {
                 return new Response(200);
             }
@@ -1936,7 +1992,7 @@ class ContainerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReturnsInvalidClassNameViaPsrContainer()
+    public function testCallableReturnsCallableThatThrowsWhenFactoryReturnsInvalidClassNameViaPsrContainer(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -1955,14 +2011,14 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testGetEnvReturnsNullWhenEnvironmentDoesNotExist()
+    public function testGetEnvReturnsNullWhenEnvironmentDoesNotExist(): void
     {
         $container = new Container([]);
 
         $this->assertNull($container->getEnv('X_FOO'));
     }
 
-    public function testGetEnvReturnsStringFromMap()
+    public function testGetEnvReturnsStringFromMap(): void
     {
         $container = new Container([
             'X_FOO' => 'bar'
@@ -1971,7 +2027,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $container->getEnv('X_FOO'));
     }
 
-    public function testGetEnvReturnsStringFromMapFactory()
+    public function testGetEnvReturnsStringFromMapFactory(): void
     {
         $container = new Container([
             'X_FOO' => function (string $bar) { return $bar; },
@@ -1981,7 +2037,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $container->getEnv('X_FOO'));
     }
 
-    public function testGetEnvReturnsStringFromGlobalServerIfNotSetInMap()
+    public function testGetEnvReturnsStringFromGlobalServerIfNotSetInMap(): void
     {
         $container = new Container([]);
 
@@ -1992,7 +2048,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $ret);
     }
 
-    public function testGetEnvReturnsStringFromPsrContainer()
+    public function testGetEnvReturnsStringFromPsrContainer(): void
     {
         $psr = $this->createMock(ContainerInterface::class);
         $psr->expects($this->once())->method('has')->with('X_FOO')->willReturn(true);
@@ -2003,7 +2059,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $container->getEnv('X_FOO'));
     }
 
-    public function testGetEnvReturnsNullIfPsrContainerHasNoEntry()
+    public function testGetEnvReturnsNullIfPsrContainerHasNoEntry(): void
     {
         $psr = $this->createMock(ContainerInterface::class);
         $psr->expects($this->once())->method('has')->with('X_FOO')->willReturn(false);
@@ -2014,7 +2070,7 @@ class ContainerTest extends TestCase
         $this->assertNull($container->getEnv('X_FOO'));
     }
 
-    public function testGetEnvReturnsStringFromGlobalServerIfPsrContainerHasNoEntry()
+    public function testGetEnvReturnsStringFromGlobalServerIfPsrContainerHasNoEntry(): void
     {
         $psr = $this->createMock(ContainerInterface::class);
         $psr->expects($this->once())->method('has')->with('X_FOO')->willReturn(false);
@@ -2029,7 +2085,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $ret);
     }
 
-    public function testGetEnvThrowsIfMapContainsInvalidType()
+    public function testGetEnvThrowsIfMapContainsInvalidType(): void
     {
         $container = new Container([
             'X_FOO' => false
@@ -2040,7 +2096,7 @@ class ContainerTest extends TestCase
         $container->getEnv('X_FOO');
     }
 
-    public function testGetEnvThrowsIfMapPsrContainerReturnsInvalidType()
+    public function testGetEnvThrowsIfMapPsrContainerReturnsInvalidType(): void
     {
         $psr = $this->createMock(ContainerInterface::class);
         $psr->expects($this->once())->method('has')->with('X_FOO')->willReturn(true);
@@ -2053,7 +2109,7 @@ class ContainerTest extends TestCase
         $container->getEnv('X_FOO');
     }
 
-    public function testGetAccessLogHandlerReturnsDefaultAccessLogHandlerInstance()
+    public function testGetAccessLogHandlerReturnsDefaultAccessLogHandlerInstance(): void
     {
         $container = new Container([]);
 
@@ -2062,7 +2118,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(AccessLogHandler::class, $accessLogHandler);
     }
 
-    public function testGetAccessLogHandlerReturnsAccessLogHandlerInstanceFromMap()
+    public function testGetAccessLogHandlerReturnsAccessLogHandlerInstanceFromMap(): void
     {
         $accessLogHandler = new AccessLogHandler();
 
@@ -2075,7 +2131,7 @@ class ContainerTest extends TestCase
         $this->assertSame($accessLogHandler, $ret);
     }
 
-    public function testGetAccessLogHandlerReturnsAccessLogHandlerInstanceFromPsrContainer()
+    public function testGetAccessLogHandlerReturnsAccessLogHandlerInstanceFromPsrContainer(): void
     {
         $accessLogHandler = new AccessLogHandler();
 
@@ -2090,7 +2146,7 @@ class ContainerTest extends TestCase
         $this->assertSame($accessLogHandler, $ret);
     }
 
-    public function testGetAccessLogHandlerReturnsDefaultAccessLogHandlerInstanceIfPsrContainerHasNoEntry()
+    public function testGetAccessLogHandlerReturnsDefaultAccessLogHandlerInstanceIfPsrContainerHasNoEntry(): void
     {
         $psr = $this->createMock(ContainerInterface::class);
         $psr->expects($this->once())->method('has')->with(AccessLogHandler::class)->willReturn(false);
@@ -2103,7 +2159,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(AccessLogHandler::class, $accessLogHandler);
     }
 
-    public function testGetErrorHandlerReturnsDefaultErrorHandlerInstance()
+    public function testGetErrorHandlerReturnsDefaultErrorHandlerInstance(): void
     {
         $container = new Container([]);
 
@@ -2112,7 +2168,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ErrorHandler::class, $errorHandler);
     }
 
-    public function testGetErrorHandlerReturnsErrorHandlerInstanceFromMap()
+    public function testGetErrorHandlerReturnsErrorHandlerInstanceFromMap(): void
     {
         $errorHandler = new ErrorHandler();
 
@@ -2125,7 +2181,7 @@ class ContainerTest extends TestCase
         $this->assertSame($errorHandler, $ret);
     }
 
-    public function testGetErrorHandlerReturnsErrorHandlerInstanceFromPsrContainer()
+    public function testGetErrorHandlerReturnsErrorHandlerInstanceFromPsrContainer(): void
     {
         $errorHandler = new ErrorHandler();
 
@@ -2140,7 +2196,7 @@ class ContainerTest extends TestCase
         $this->assertSame($errorHandler, $ret);
     }
 
-    public function testGetErrorHandlerReturnsDefaultErrorHandlerInstanceIfPsrContainerHasNoEntry()
+    public function testGetErrorHandlerReturnsDefaultErrorHandlerInstanceIfPsrContainerHasNoEntry(): void
     {
         $psr = $this->createMock(ContainerInterface::class);
         $psr->expects($this->once())->method('has')->with(ErrorHandler::class)->willReturn(false);
@@ -2153,7 +2209,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ErrorHandler::class, $errorHandler);
     }
 
-    public function testInvokeContainerAsMiddlewareReturnsFromNextRequestHandler()
+    public function testInvokeContainerAsMiddlewareReturnsFromNextRequestHandler(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
         $response = new Response(200, [], '');
@@ -2164,7 +2220,7 @@ class ContainerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeContainerAsFinalRequestHandlerThrows()
+    public function testInvokeContainerAsFinalRequestHandlerThrows(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -2175,7 +2231,7 @@ class ContainerTest extends TestCase
         $container($request);
     }
 
-    public function testCtorWithInvalidValueThrows()
+    public function testCtorWithInvalidValueThrows(): void
     {
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Argument #1 ($loader) must be of type array|Psr\Container\ContainerInterface, stdClass given');

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -451,6 +451,7 @@ class ErrorHandlerTest extends TestCase
         $ref = new \ReflectionMethod($handler, 'errorInvalidException');
         $ref->setAccessible(true);
         $response = $ref->invoke($handler, $e);
+        assert($response instanceof ResponseInterface);
 
         $this->assertStringContainsString("<title>Error 500: Internal Server Error</title>\n", (string) $response->getBody());
         $this->assertStringContainsString("<p>The requested page failed to load, please try again later.</p>\n", (string) $response->getBody());
@@ -508,6 +509,7 @@ class ErrorHandlerTest extends TestCase
         $ref = new \ReflectionMethod($handler, 'errorInvalidResponse');
         $ref->setAccessible(true);
         $response = $ref->invoke($handler, $value);
+        assert($response instanceof ResponseInterface);
 
         $this->assertStringContainsString("<title>Error 500: Internal Server Error</title>\n", (string) $response->getBody());
         $this->assertStringContainsString("<p>The requested page failed to load, please try again later.</p>\n", (string) $response->getBody());
@@ -529,6 +531,7 @@ class ErrorHandlerTest extends TestCase
         $ref = new \ReflectionMethod($handler, 'errorInvalidCoroutine');
         $ref->setAccessible(true);
         $response = $ref->invoke($handler, $value, $file, $line);
+        assert($response instanceof ResponseInterface);
 
         $this->assertStringContainsString("<title>Error 500: Internal Server Error</title>\n", (string) $response->getBody());
         $this->assertStringContainsString("<p>The requested page failed to load, please try again later.</p>\n", (string) $response->getBody());

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -13,7 +13,7 @@ use function React\Promise\resolve;
 
 class ErrorHandlerTest extends TestCase
 {
-    public function testInvokeWithHandlerReturningResponseReturnsSameResponse()
+    public function testInvokeWithHandlerReturningResponseReturnsSameResponse(): void
     {
         $handler = new ErrorHandler();
 
@@ -25,7 +25,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningPromiseResolvingWithResponseReturnsPromiseResolvingWithSameResponse()
+    public function testInvokeWithHandlerReturningPromiseResolvingWithResponseReturnsPromiseResolvingWithSameResponse(): void
     {
         $handler = new ErrorHandler();
 
@@ -45,7 +45,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningGeneratorReturningResponseReturnsGeneratorYieldingSameResponse()
+    public function testInvokeWithHandlerReturningGeneratorReturningResponseReturnsGeneratorYieldingSameResponse(): void
     {
         $handler = new ErrorHandler();
 
@@ -66,7 +66,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningGeneratorYieldingResolvedPromiseThenReturningResponseReturnsGeneratorYieldingSameResponse()
+    public function testInvokeWithHandlerReturningGeneratorYieldingResolvedPromiseThenReturningResponseReturnsGeneratorYieldingSameResponse(): void
     {
         $handler = new ErrorHandler();
 
@@ -87,7 +87,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningGeneratorYieldingRejectedPromiseInTryCatchThenReturningResponseReturnsGeneratorYieldingSameResponse()
+    public function testInvokeWithHandlerReturningGeneratorYieldingRejectedPromiseInTryCatchThenReturningResponseReturnsGeneratorYieldingSameResponse(): void
     {
         $handler = new ErrorHandler();
 
@@ -121,7 +121,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerThrowingExceptionReturnsError500Response()
+    public function testInvokeWithHandlerThrowingExceptionReturnsError500Response(): void
     {
         $handler = new ErrorHandler();
 
@@ -136,7 +136,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testInvokeWithHandlerReturningPromiseRejectingWithExceptionReturnsPromiseResolvingWithError500Response()
+    public function testInvokeWithHandlerReturningPromiseRejectingWithExceptionReturnsPromiseResolvingWithError500Response(): void
     {
         $handler = new ErrorHandler();
 
@@ -159,7 +159,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testInvokeWithHandlerReturningGeneratorThrowingExceptionReturnsGeneratorYieldingError500Response()
+    public function testInvokeWithHandlerReturningGeneratorThrowingExceptionReturnsGeneratorYieldingError500Response(): void
     {
         $handler = new ErrorHandler();
 
@@ -181,7 +181,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testInvokeWithHandlerReturningGeneratorYieldingPromiseThenThrowingExceptionReturnsGeneratorYieldingError500Response()
+    public function testInvokeWithHandlerReturningGeneratorYieldingPromiseThenThrowingExceptionReturnsGeneratorYieldingError500Response(): void
     {
         $handler = new ErrorHandler();
 
@@ -202,7 +202,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testInvokeWithHandlerReturningGeneratorYieldingPromiseRejectingWithExceptionReturnsGeneratorYieldingError500Response()
+    public function testInvokeWithHandlerReturningGeneratorYieldingPromiseRejectingWithExceptionReturnsGeneratorYieldingError500Response(): void
     {
         $handler = new ErrorHandler();
 
@@ -233,7 +233,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testInvokeWithHandlerReturningNullReturnsError500Response()
+    public function testInvokeWithHandlerReturningNullReturnsError500Response(): void
     {
         $handler = new ErrorHandler();
 
@@ -248,7 +248,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testInvokeWithHandlerReturningPromiseResolvingWithNullReturnsPromiseResolvingWithError500Response()
+    public function testInvokeWithHandlerReturningPromiseResolvingWithNullReturnsPromiseResolvingWithError500Response(): void
     {
         $handler = new ErrorHandler();
 
@@ -271,7 +271,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testInvokeWithHandlerReturningPromiseRejectingWithNullReturnsPromiseResolvingWithError500Response()
+    public function testInvokeWithHandlerReturningPromiseRejectingWithNullReturnsPromiseResolvingWithError500Response(): void
     {
         if (method_exists(PromiseInterface::class, 'catch')) {
             $this->markTestSkipped('Only supported for legacy Promise v2, Promise v3 always rejects with Throwable');
@@ -298,7 +298,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testInvokeWithHandlerReturningGeneratorYieldingNullReturnsGeneratorYieldingError500Response()
+    public function testInvokeWithHandlerReturningGeneratorYieldingNullReturnsGeneratorYieldingError500Response(): void
     {
         $handler = new ErrorHandler();
 
@@ -317,7 +317,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testInvokeWithHandlerReturningGeneratorReturningNullReturnsGeneratorYieldingError500Response()
+    public function testInvokeWithHandlerReturningGeneratorReturningNullReturnsGeneratorYieldingError500Response(): void
     {
         $handler = new ErrorHandler();
 
@@ -339,7 +339,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
     }
 
-    public function testRequestNotFoundReturnsError404()
+    public function testRequestNotFoundReturnsError404(): void
     {
         $handler = new ErrorHandler();
         $response = $handler->requestNotFound();
@@ -354,7 +354,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Please check the URL in the address bar and try again.</p>\n", (string) $response->getBody());
     }
 
-    public function testRequestMethodNotAllowedReturnsError405WithSingleAllowedMethod()
+    public function testRequestMethodNotAllowedReturnsError405WithSingleAllowedMethod(): void
     {
         $handler = new ErrorHandler();
         $response = $handler->requestMethodNotAllowed(['GET']);
@@ -365,7 +365,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Please check the URL in the address bar and try again with <code>GET</code> request.</p>\n", (string) $response->getBody());
     }
 
-    public function testRequestMethodNotAllowedReturnsError405WithMultipleAllowedMethods()
+    public function testRequestMethodNotAllowedReturnsError405WithMultipleAllowedMethods(): void
     {
         $handler = new ErrorHandler();
         $response = $handler->requestMethodNotAllowed(['GET', 'HEAD', 'POST']);
@@ -376,7 +376,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Please check the URL in the address bar and try again with <code>GET</code>/<code>HEAD</code>/<code>POST</code> request.</p>\n", (string) $response->getBody());
     }
 
-    public function testRequestProxyUnsupportedReturnsError400()
+    public function testRequestProxyUnsupportedReturnsError400(): void
     {
         $handler = new ErrorHandler();
         $response = $handler->requestProxyUnsupported();
@@ -386,7 +386,8 @@ class ErrorHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Please check your settings and retry.</p>\n", (string) $response->getBody());
     }
 
-    public function provideExceptionMessage()
+    /** @return list<list<string>> */
+    public function provideExceptionMessage(): array
     {
         return [
             [
@@ -439,7 +440,7 @@ class ErrorHandlerTest extends TestCase
     /**
      * @dataProvider provideExceptionMessage
      */
-    public function testErrorInvalidExceptionReturnsError500(string $in, string $expected)
+    public function testErrorInvalidExceptionReturnsError500(string $in, string $expected): void
     {
         $handler = new ErrorHandler();
 
@@ -456,7 +457,8 @@ class ErrorHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>RuntimeException</code> with message <code>$expected</code> in <code title=\"See " . __FILE__ . " line $line\">ErrorHandlerTest.php:$line</code>.</p>\n", (string) $response->getBody());
     }
 
-    public function provideInvalidReturnValue()
+    /** @return list<list<mixed>> */
+    public function provideInvalidReturnValue(): array
     {
         return [
             [
@@ -498,7 +500,7 @@ class ErrorHandlerTest extends TestCase
      * @dataProvider provideInvalidReturnValue
      * @param mixed $value
      */
-    public function testErrorInvalidResponseReturnsError500($value, string $name)
+    public function testErrorInvalidResponseReturnsError500($value, string $name): void
     {
         $handler = new ErrorHandler();
 
@@ -516,7 +518,7 @@ class ErrorHandlerTest extends TestCase
      * @dataProvider provideInvalidReturnValue
      * @param mixed $value
      */
-    public function testErrorInvalidCoroutineReturnsError500($value, string $name)
+    public function testErrorInvalidCoroutineReturnsError500($value, string $name): void
     {
         $handler = new ErrorHandler();
 

--- a/tests/FilesystemHandlerTest.php
+++ b/tests/FilesystemHandlerTest.php
@@ -9,7 +9,7 @@ use React\Http\Message\ServerRequest;
 
 class FilesystemHandlerTest extends TestCase
 {
-    public function testInvokeWithValidPathToComposerJsonWillReturnResponseWithFileContentsAndContentType()
+    public function testInvokeWithValidPathToComposerJsonWillReturnResponseWithFileContentsAndContentType(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -25,7 +25,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertEquals(file_get_contents(__DIR__ . '/../composer.json'), (string) $response->getBody());
     }
 
-    public function testInvokeWithValidPathToLicenseWillReturnResponseWithFileContentsAndDefaultContentType()
+    public function testInvokeWithValidPathToLicenseWillReturnResponseWithFileContentsAndDefaultContentType(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -41,7 +41,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertEquals(file_get_contents(__DIR__ . '/../LICENSE'), (string) $response->getBody());
     }
 
-    public function testInvokeWithValidPathToOneCharacterFilenameWillReturnResponseWithFileContentsAndDefaultContentType()
+    public function testInvokeWithValidPathToOneCharacterFilenameWillReturnResponseWithFileContentsAndDefaultContentType(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -57,7 +57,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertEquals(file_get_contents(__DIR__ . '/data/a'), (string) $response->getBody());
     }
 
-    public function testInvokeWithValidPathToTwoCharacterFilenameWillReturnResponseWithFileContentsAndDefaultContentType()
+    public function testInvokeWithValidPathToTwoCharacterFilenameWillReturnResponseWithFileContentsAndDefaultContentType(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -73,7 +73,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertEquals(file_get_contents(__DIR__ . '/data/bb'), (string) $response->getBody());
     }
 
-    public function testInvokeWithValidPathToComposerJsonAndCachingHeaderWillReturnResponseNotModifiedWithoutContents()
+    public function testInvokeWithValidPathToComposerJsonAndCachingHeaderWillReturnResponseNotModifiedWithoutContents(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -93,7 +93,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertEquals('', (string) $response->getBody());
     }
 
-    public function testInvokeWithInvalidPathWillReturnNotFoundResponse()
+    public function testInvokeWithInvalidPathWillReturnNotFoundResponse(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -109,7 +109,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertStringContainsString("<title>Error 404: Page Not Found</title>\n", (string) $response->getBody());
     }
 
-    public function testInvokeWithDoubleSlashWillReturnNotFoundResponse()
+    public function testInvokeWithDoubleSlashWillReturnNotFoundResponse(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -125,7 +125,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertStringContainsString("<title>Error 404: Page Not Found</title>\n", (string) $response->getBody());
     }
 
-    public function testInvokeWithPathWithLeadingSlashWillReturnNotFoundResponse()
+    public function testInvokeWithPathWithLeadingSlashWillReturnNotFoundResponse(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -141,7 +141,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertStringContainsString("<title>Error 404: Page Not Found</title>\n", (string) $response->getBody());
     }
 
-    public function testInvokeWithPathWithDotSegmentWillReturnNotFoundResponse()
+    public function testInvokeWithPathWithDotSegmentWillReturnNotFoundResponse(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -157,7 +157,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertStringContainsString("<title>Error 404: Page Not Found</title>\n", (string) $response->getBody());
     }
 
-    public function testInvokeWithPathBelowRootWillReturnNotFoundResponse()
+    public function testInvokeWithPathBelowRootWillReturnNotFoundResponse(): void
     {
         $handler = new FilesystemHandler(__DIR__);
 
@@ -173,7 +173,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertStringContainsString("<title>Error 404: Page Not Found</title>\n", (string) $response->getBody());
     }
 
-    public function testInvokeWithBinaryPathWillReturnNotFoundResponse()
+    public function testInvokeWithBinaryPathWillReturnNotFoundResponse(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -189,7 +189,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertStringContainsString("<title>Error 404: Page Not Found</title>\n", (string) $response->getBody());
     }
 
-    public function testInvokeWithoutPathWillReturnResponseWithDirectoryListing()
+    public function testInvokeWithoutPathWillReturnResponseWithDirectoryListing(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -206,7 +206,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertStringNotContainsString('<a href="../">../</a>', (string) $response->getBody());
     }
 
-    public function testInvokeWithEmptyPathWillReturnResponseWithDirectoryListing()
+    public function testInvokeWithEmptyPathWillReturnResponseWithDirectoryListing(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -224,7 +224,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertStringNotContainsString('<a href="../">../</a>', (string) $response->getBody());
     }
 
-    public function testInvokeWithoutPathAndRootIsFileWillReturnResponseWithFileContents()
+    public function testInvokeWithoutPathAndRootIsFileWillReturnResponseWithFileContents(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__) . '/LICENSE');
 
@@ -239,7 +239,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertEquals(file_get_contents(__DIR__ . '/../LICENSE'), (string) $response->getBody());
     }
 
-    public function testInvokeWithValidPathToDirectoryWillReturnResponseWithDirectoryListing()
+    public function testInvokeWithValidPathToDirectoryWillReturnResponseWithDirectoryListing(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -255,7 +255,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertEquals("<strong>.github/</strong>\n<ul>\n    <li><a href=\"../\">../</a></li>\n    <li><a href=\"FUNDING.yml\">FUNDING.yml</a></li>\n    <li><a href=\"ISSUE_TEMPLATE/\">ISSUE_TEMPLATE/</a></li>\n    <li><a href=\"workflows/\">workflows/</a></li>\n</ul>\n", (string) $response->getBody());
     }
 
-    public function testInvokeWithValidPathToDirectoryButWithoutTrailingSlashWillReturnRedirectToPathWithSlash()
+    public function testInvokeWithValidPathToDirectoryButWithoutTrailingSlashWillReturnRedirectToPathWithSlash(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 
@@ -275,7 +275,7 @@ class FilesystemHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Redirecting to <a href=\".github/\"><code>.github/</code></a>...</p>\n", (string) $response->getBody());
     }
 
-    public function testInvokeWithValidPathToFileButWithTrailingSlashWillReturnRedirectToPathWithoutSlash()
+    public function testInvokeWithValidPathToFileButWithTrailingSlashWillReturnRedirectToPathWithoutSlash(): void
     {
         $handler = new FilesystemHandler(dirname(__DIR__));
 

--- a/tests/Io/FiberHandlerTest.php
+++ b/tests/Io/FiberHandlerTest.php
@@ -21,7 +21,7 @@ class FiberHandlerTest extends TestCase
         }
     }
 
-    public function testInvokeWithHandlerReturningResponseReturnsSameResponse()
+    public function testInvokeWithHandlerReturningResponseReturnsSameResponse(): void
     {
         $handler = new FiberHandler();
 
@@ -33,7 +33,7 @@ class FiberHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningPromiseResolvingWithResponseReturnsPromiseResolvingWithSameResponse()
+    public function testInvokeWithHandlerReturningPromiseResolvingWithResponseReturnsPromiseResolvingWithSameResponse(): void
     {
         $handler = new FiberHandler();
 
@@ -53,7 +53,7 @@ class FiberHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningGeneratorReturningResponseReturnsGeneratorReturningSameResponse()
+    public function testInvokeWithHandlerReturningGeneratorReturningResponseReturnsGeneratorReturningSameResponse(): void
     {
         $handler = new FiberHandler();
 
@@ -74,7 +74,7 @@ class FiberHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningGeneratorReturningResponseAfterYieldingResolvedPromiseReturnsGeneratorReturningSameResponse()
+    public function testInvokeWithHandlerReturningGeneratorReturningResponseAfterYieldingResolvedPromiseReturnsGeneratorReturningSameResponse(): void
     {
         $handler = new FiberHandler();
 
@@ -93,7 +93,7 @@ class FiberHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningGeneratorReturningResponseAfterYieldingRejectedPromiseReturnsGeneratorReturningSameResponse()
+    public function testInvokeWithHandlerReturningGeneratorReturningResponseAfterYieldingRejectedPromiseReturnsGeneratorReturningSameResponse(): void
     {
         $handler = new FiberHandler();
 
@@ -116,7 +116,7 @@ class FiberHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningResponseAfterAwaitingResolvedPromiseReturnsSameResponse()
+    public function testInvokeWithHandlerReturningResponseAfterAwaitingResolvedPromiseReturnsSameResponse(): void
     {
         $handler = new FiberHandler();
 
@@ -130,7 +130,7 @@ class FiberHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testInvokeWithHandlerReturningResponseAfterAwaitingPendingPromiseReturnsPromiseResolvingWithSameResponse()
+    public function testInvokeWithHandlerReturningResponseAfterAwaitingPendingPromiseReturnsPromiseResolvingWithSameResponse(): void
     {
         $handler = new FiberHandler();
 

--- a/tests/Io/HtmlHandlerTest.php
+++ b/tests/Io/HtmlHandlerTest.php
@@ -12,14 +12,15 @@ class HtmlHandlerTest extends TestCase
      * @param string $in
      * @param string $expected
      */
-    public function testEscapeHtml(string $in, string $expected)
+    public function testEscapeHtml(string $in, string $expected): void
     {
         $html = new HtmlHandler();
 
         $this->assertEquals($expected, $html->escape($in));
     }
 
-    public function provideNames()
+    /** @return list<list<string>> */
+    public function provideNames(): array
     {
         return [
             [

--- a/tests/Io/MiddlewareHandlerTest.php
+++ b/tests/Io/MiddlewareHandlerTest.php
@@ -11,7 +11,7 @@ use React\Http\Message\ServerRequest;
 
 class MiddlewareHandlerTest extends TestCase
 {
-    public function testOneMiddleware()
+    public function testOneMiddleware(): void
     {
         $handler = new MiddlewareHandler([
             function (ServerRequestInterface $request, callable $next) {
@@ -39,10 +39,11 @@ class MiddlewareHandlerTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testOneMiddlewareClass()
+    public function testOneMiddlewareClass(): void
     {
         $middleware = new class{
-            public function __invoke(ServerRequestInterface $request, callable $next) {
+            public function __invoke(ServerRequestInterface $request, callable $next): Response
+            {
                 return $next($request);
             }
         };
@@ -71,7 +72,7 @@ class MiddlewareHandlerTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testTwoMiddleware()
+    public function testTwoMiddleware(): void
     {
         $handler = new MiddlewareHandler([
             function (ServerRequestInterface $request, callable $next) {
@@ -102,7 +103,7 @@ class MiddlewareHandlerTest extends TestCase
         $this->assertEquals("OK\n", (string) $response->getBody());
     }
 
-    public function testThreeMiddleware()
+    public function testThreeMiddleware(): void
     {
         $handler = new MiddlewareHandler([
             function (ServerRequestInterface $request, callable $next) {

--- a/tests/Io/RedirectHandlerTest.php
+++ b/tests/Io/RedirectHandlerTest.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class RedirectHandlerTest extends TestCase
 {
-    public function testInvokeReturnsResponseWithRedirectToGivenLocation()
+    public function testInvokeReturnsResponseWithRedirectToGivenLocation(): void
     {
         $handler = new RedirectHandler('http://example.com/');
 
@@ -29,7 +29,7 @@ class RedirectHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Redirecting to <a href=\"http://example.com/\"><code>http://example.com/</code></a>...</p>\n", (string) $response->getBody());
     }
 
-    public function testInvokeReturnsResponseWithPermanentRedirectToGivenLocationAndCode()
+    public function testInvokeReturnsResponseWithPermanentRedirectToGivenLocationAndCode(): void
     {
         $handler = new RedirectHandler('/', 301);
 
@@ -46,7 +46,7 @@ class RedirectHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Redirecting to <a href=\"/\"><code>/</code></a>...</p>\n", (string) $response->getBody());
     }
 
-    public function testInvokeReturnsResponseWithCustomRedirectStatusCodeAndGivenLocation()
+    public function testInvokeReturnsResponseWithCustomRedirectStatusCodeAndGivenLocation(): void
     {
         $handler = new RedirectHandler('/', 399);
 
@@ -63,7 +63,7 @@ class RedirectHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Redirecting to <a href=\"/\"><code>/</code></a>...</p>\n", (string) $response->getBody());
     }
 
-    public function testInvokeReturnsResponseWithRedirectToGivenLocationWithSpecialCharsEncoded()
+    public function testInvokeReturnsResponseWithRedirectToGivenLocationWithSpecialCharsEncoded(): void
     {
         $handler = new RedirectHandler('/hello%20w%7Frld?a=1&b=2');
 
@@ -80,19 +80,19 @@ class RedirectHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Redirecting to <a href=\"/hello%20w%7Frld?a=1&amp;b=2\"><code>/hello%20w%7Frld?a=1&amp;b=2</code></a>...</p>\n", (string) $response->getBody());
     }
 
-    public function testConstructWithSuccessCodeThrows()
+    public function testConstructWithSuccessCodeThrows(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         new RedirectHandler('/', 200);
     }
 
-    public function testConstructWithNotModifiedCodeThrows()
+    public function testConstructWithNotModifiedCodeThrows(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         new RedirectHandler('/', 304);
     }
 
-    public function testConstructWithBadRequestCodeThrows()
+    public function testConstructWithBadRequestCodeThrows(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         new RedirectHandler('/', 400);

--- a/tests/Io/RouteHandlerTest.php
+++ b/tests/Io/RouteHandlerTest.php
@@ -158,7 +158,7 @@ class RouteHandlerTest extends TestCase
         $controller = new class {
             /** @var ?Response */
             public static $response;
-            public function __invoke(): Response {
+            public function __invoke(): ?Response {
                 return self::$response;
             }
         };
@@ -180,7 +180,7 @@ class RouteHandlerTest extends TestCase
         $controller = new class {
             /** @var ?Response */
             public static $response;
-            public function __invoke(): Response
+            public function __invoke(): ?Response
             {
                 return self::$response;
             }
@@ -207,7 +207,7 @@ class RouteHandlerTest extends TestCase
             {
                 assert($value === null);
             }
-            public function __invoke(): Response
+            public function __invoke(): ?Response
             {
                 return self::$response;
             }
@@ -234,7 +234,7 @@ class RouteHandlerTest extends TestCase
             {
                 assert($value === null);
             }
-            public function __invoke(): Response
+            public function __invoke(): ?Response
             {
                 return self::$response;
             }
@@ -260,7 +260,7 @@ class RouteHandlerTest extends TestCase
             {
                 self::$response = $response;
             }
-            public function __invoke(): Response
+            public function __invoke(): ?Response
             {
                 return self::$response;
             }

--- a/tests/Io/RouteHandlerTest.php
+++ b/tests/Io/RouteHandlerTest.php
@@ -14,7 +14,7 @@ use React\Http\Message\ServerRequest;
 
 class RouteHandlerTest extends TestCase
 {
-    public function testMapRouteWithControllerAddsRouteOnRouter()
+    public function testMapRouteWithControllerAddsRouteOnRouter(): void
     {
         $controller = function () { };
 
@@ -30,7 +30,7 @@ class RouteHandlerTest extends TestCase
         $handler->map(['GET'], '/', $controller);
     }
 
-    public function testMapRouteWithMiddlewareAndControllerAddsRouteWithMiddlewareHandlerOnRouter()
+    public function testMapRouteWithMiddlewareAndControllerAddsRouteWithMiddlewareHandlerOnRouter(): void
     {
         $middleware = function () { };
         $controller = function () { };
@@ -47,7 +47,7 @@ class RouteHandlerTest extends TestCase
         $handler->map(['GET'], '/', $middleware, $controller);
     }
 
-    public function testMapRouteWithClassNameAddsRouteOnRouterWithControllerCallableFromContainer()
+    public function testMapRouteWithClassNameAddsRouteOnRouterWithControllerCallableFromContainer(): void
     {
         $controller = function () { };
 
@@ -66,7 +66,7 @@ class RouteHandlerTest extends TestCase
         $handler->map(['GET'], '/', \stdClass::class);
     }
 
-    public function testMapRouteWithContainerAndControllerAddsRouteOnRouterWithControllerOnly()
+    public function testMapRouteWithContainerAndControllerAddsRouteOnRouterWithControllerOnly(): void
     {
         $controller = function () { };
 
@@ -82,7 +82,7 @@ class RouteHandlerTest extends TestCase
         $handler->map(['GET'], '/', new Container(), $controller);
     }
 
-    public function testMapRouteWithContainerAndControllerClassNameAddsRouteOnRouterWithControllerCallableFromContainer()
+    public function testMapRouteWithContainerAndControllerClassNameAddsRouteOnRouterWithControllerCallableFromContainer(): void
     {
         $controller = function () { };
 
@@ -101,7 +101,7 @@ class RouteHandlerTest extends TestCase
         $handler->map(['GET'], '/', $container, \stdClass::class);
     }
 
-    public function testHandleRequestWithProxyRequestReturnsResponseWithMessageThatProxyRequestsAreNotAllowed()
+    public function testHandleRequestWithProxyRequestReturnsResponseWithMessageThatProxyRequestsAreNotAllowed(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
         $request = $request->withRequestTarget('http://example.com/');
@@ -119,7 +119,7 @@ class RouteHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Please check your settings and retry.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithConnectProxyRequestReturnsResponseWithMessageThatProxyRequestsAreNotAllowed()
+    public function testHandleRequestWithConnectProxyRequestReturnsResponseWithMessageThatProxyRequestsAreNotAllowed(): void
     {
         $request = new ServerRequest('CONNECT', 'example.com:80');
         $request = $request->withRequestTarget('example.com:80');
@@ -137,7 +137,7 @@ class RouteHandlerTest extends TestCase
         $this->assertStringContainsString("<p>Please check your settings and retry.</p>\n", (string) $response->getBody());
     }
 
-    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandler()
+    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandler(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
         $response = new Response(200, [], '');
@@ -150,14 +150,15 @@ class RouteHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClass()
+    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClass(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
         $response = new Response(200, [], '');
 
         $controller = new class {
+            /** @var ?Response */
             public static $response;
-            public function __invoke() {
+            public function __invoke(): Response {
                 return self::$response;
             }
         };
@@ -171,14 +172,16 @@ class RouteHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClassName()
+    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClassName(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
         $response = new Response(200, [], '');
 
         $controller = new class {
+            /** @var ?Response */
             public static $response;
-            public function __invoke() {
+            public function __invoke(): Response
+            {
                 return self::$response;
             }
         };
@@ -192,17 +195,20 @@ class RouteHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClassNameWithOptionalConstructor()
+    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClassNameWithOptionalConstructor(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
         $response = new Response(200, [], '');
 
         $controller = new class {
+            /** @var ?Response */
             public static $response;
-            public function __construct(int $value = null) {
+            public function __construct(int $value = null)
+            {
                 assert($value === null);
             }
-            public function __invoke() {
+            public function __invoke(): Response
+            {
                 return self::$response;
             }
         };
@@ -216,17 +222,20 @@ class RouteHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClassNameWithNullableConstructor()
+    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClassNameWithNullableConstructor(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
         $response = new Response(200, [], '');
 
         $controller = new class(null) {
+            /** @var ?Response */
             public static $response;
-            public function __construct(?int $value) {
+            public function __construct(?int $value)
+            {
                 assert($value === null);
             }
-            public function __invoke() {
+            public function __invoke(): Response
+            {
                 return self::$response;
             }
         };
@@ -240,16 +249,19 @@ class RouteHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClassNameWithRequiredResponseInConstructor()
+    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerClassNameWithRequiredResponseInConstructor(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class(new Response(500)) {
+            /** @var ?Response */
             public static $response;
-            public function __construct(Response $response) {
+            public function __construct(Response $response)
+            {
                 self::$response = $response;
             }
-            public function __invoke() {
+            public function __invoke(): Response
+            {
                 return self::$response;
             }
         };
@@ -262,13 +274,14 @@ class RouteHandlerTest extends TestCase
         $this->assertSame($controller::$response, $ret);
     }
 
-    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerWithClassNameMiddleware()
+    public function testHandleRequestWithGetRequestReturnsResponseFromMatchingHandlerWithClassNameMiddleware(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
         $response = new Response(200, [], '');
 
         $middleware = new class {
-            public function __invoke(ServerRequestInterface $request, callable $next) {
+            public function __invoke(ServerRequestInterface $request, callable $next): Response
+            {
                 return $next($request);
             }
         };
@@ -281,13 +294,15 @@ class RouteHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testHandleRequestTwiceWithGetRequestCallsSameHandlerInstanceFromMatchingHandlerClassName()
+    public function testHandleRequestTwiceWithGetRequestCallsSameHandlerInstanceFromMatchingHandlerClassName(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 
         $controller = new class {
+            /** @var int */
             private $called = 0;
-            public function __invoke() {
+            public function __invoke(): int
+            {
                 return ++$this->called;
             }
         };
@@ -302,7 +317,7 @@ class RouteHandlerTest extends TestCase
         $this->assertEquals(2, $ret);
     }
 
-    public function testHandleRequestWithGetRequestWithHttpUrlInPathReturnsResponseFromMatchingHandler()
+    public function testHandleRequestWithGetRequestWithHttpUrlInPathReturnsResponseFromMatchingHandler(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/http://localhost/');
         $response = new Response(200, [], '');
@@ -315,7 +330,7 @@ class RouteHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testHandleRequestWithOptionsAsteriskRequestReturnsResponseFromMatchingEmptyHandler()
+    public function testHandleRequestWithOptionsAsteriskRequestReturnsResponseFromMatchingEmptyHandler(): void
     {
         $request = new ServerRequest('OPTIONS', 'http://example.com');
         $request = $request->withRequestTarget('*');
@@ -329,7 +344,7 @@ class RouteHandlerTest extends TestCase
         $this->assertSame($response, $ret);
     }
 
-    public function testHandleRequestWithContainerOnlyThrows()
+    public function testHandleRequestWithContainerOnlyThrows(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
 

--- a/tests/Io/SapiHandlerTest.php
+++ b/tests/Io/SapiHandlerTest.php
@@ -9,7 +9,7 @@ use React\Stream\ThroughStream;
 
 class SapiHandlerTest extends TestCase
 {
-    public function testRequestFromGlobalsWithNoServerVariablesDefaultsToGetRequestToLocalhost()
+    public function testRequestFromGlobalsWithNoServerVariablesDefaultsToGetRequestToLocalhost(): void
     {
         $sapi = new SapiHandler();
         $request = $sapi->requestFromGlobals();
@@ -23,7 +23,7 @@ class SapiHandlerTest extends TestCase
     /**
      * @backupGlobals enabled
      */
-    public function testRequestFromGlobalsWithHeadRequest()
+    public function testRequestFromGlobalsWithHeadRequest(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'HEAD';
         $_SERVER['REQUEST_URI'] = '//';
@@ -42,7 +42,7 @@ class SapiHandlerTest extends TestCase
     /**
      * @backupGlobals enabled
      */
-    public function testRequestFromGlobalsWithGetRequestOverCustomPort()
+    public function testRequestFromGlobalsWithGetRequestOverCustomPort(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_SERVER['REQUEST_URI'] = '/path';
@@ -61,7 +61,7 @@ class SapiHandlerTest extends TestCase
     /**
      * @backupGlobals enabled
      */
-    public function testRequestFromGlobalsWithGetRequestOverHttps()
+    public function testRequestFromGlobalsWithGetRequestOverHttps(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_SERVER['REQUEST_URI'] = '/';
@@ -81,7 +81,7 @@ class SapiHandlerTest extends TestCase
     /**
      * @backupGlobals enabled
      */
-    public function testRequestFromGlobalsWithOptionsAsterisk()
+    public function testRequestFromGlobalsWithOptionsAsterisk(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
         $_SERVER['REQUEST_URI'] = '*';
@@ -101,7 +101,7 @@ class SapiHandlerTest extends TestCase
     /**
      * @backupGlobals enabled
      */
-    public function testRequestFromGlobalsWithGetProxy()
+    public function testRequestFromGlobalsWithGetProxy(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_SERVER['REQUEST_URI'] = 'http://example.com/';
@@ -121,7 +121,7 @@ class SapiHandlerTest extends TestCase
     /**
      * @backupGlobals enabled
      */
-    public function testRequestFromGlobalsWithConnectProxy()
+    public function testRequestFromGlobalsWithConnectProxy(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'CONNECT';
         $_SERVER['REQUEST_URI'] = 'example.com:443';
@@ -138,7 +138,7 @@ class SapiHandlerTest extends TestCase
         $this->assertEquals('example.com:443', $request->getHeaderLine('Host'));
     }
 
-    public function testSendResponseSendsEmptyResponseWithNoHeadersAndEmptyBodyAndAssignsNoContentTypeAndEmptyContentLength()
+    public function testSendResponseSendsEmptyResponseWithNoHeadersAndEmptyBodyAndAssignsNoContentTypeAndEmptyContentLength(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -153,7 +153,7 @@ class SapiHandlerTest extends TestCase
         $this->assertEquals(['Content-Type:', 'Content-Length: 0'], xdebug_get_headers());
     }
 
-    public function testSendResponseSendsJsonResponseWithGivenHeadersAndBodyAndAssignsMatchingContentLength()
+    public function testSendResponseSendsJsonResponseWithGivenHeadersAndBodyAndAssignsMatchingContentLength(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -173,7 +173,7 @@ class SapiHandlerTest extends TestCase
     /**
      * @backupGlobals enabled
      */
-    public function testSendResponseSendsJsonResponseWithGivenHeadersAndMatchingContentLengthButEmptyBodyForHeadRequest()
+    public function testSendResponseSendsJsonResponseWithGivenHeadersAndMatchingContentLengthButEmptyBodyForHeadRequest(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -191,7 +191,7 @@ class SapiHandlerTest extends TestCase
         $this->assertEquals(array_merge($previous, ['Content-Type: application/json', 'Content-Length: 2']), xdebug_get_headers());
     }
 
-    public function testSendResponseSendsEmptyBodyWithGivenHeadersAndAssignsNoContentLengthForNoContentResponse()
+    public function testSendResponseSendsEmptyBodyWithGivenHeadersAndAssignsNoContentLengthForNoContentResponse(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -208,7 +208,7 @@ class SapiHandlerTest extends TestCase
         $this->assertEquals(array_merge($previous, ['Content-Type: application/json']), xdebug_get_headers());
     }
 
-    public function testSendResponseSendsEmptyBodyWithGivenHeadersButWithoutExplicitContentLengthForNoContentResponse()
+    public function testSendResponseSendsEmptyBodyWithGivenHeadersButWithoutExplicitContentLengthForNoContentResponse(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -225,7 +225,7 @@ class SapiHandlerTest extends TestCase
         $this->assertEquals(array_merge($previous, ['Content-Type: application/json']), xdebug_get_headers());
     }
 
-    public function testSendResponseSendsEmptyBodyWithGivenHeadersAndAssignsContentLengthForNotModifiedResponse()
+    public function testSendResponseSendsEmptyBodyWithGivenHeadersAndAssignsContentLengthForNotModifiedResponse(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -242,7 +242,7 @@ class SapiHandlerTest extends TestCase
         $this->assertEquals(array_merge($previous, ['Content-Type: application/json', 'Content-Length: 4']), xdebug_get_headers());
     }
 
-    public function testSendResponseSendsEmptyBodyWithGivenHeadersAndExplicitContentLengthForNotModifiedResponse()
+    public function testSendResponseSendsEmptyBodyWithGivenHeadersAndExplicitContentLengthForNotModifiedResponse(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -259,7 +259,7 @@ class SapiHandlerTest extends TestCase
         $this->assertEquals(array_merge($previous, ['Content-Type: application/json', 'Content-Length: 2']), xdebug_get_headers());
     }
 
-    public function testSendResponseSendsStreamingResponseWithNoHeadersAndBodyFromStreamData()
+    public function testSendResponseSendsStreamingResponseWithNoHeadersAndBodyFromStreamData(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -282,7 +282,7 @@ class SapiHandlerTest extends TestCase
     /**
      * @backupGlobals enabled
      */
-    public function testSendResponseClosesStreamingResponseAndSendsResponseWithNoHeadersAndBodyForHeadRequest()
+    public function testSendResponseClosesStreamingResponseAndSendsResponseWithNoHeadersAndBodyForHeadRequest(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -302,7 +302,7 @@ class SapiHandlerTest extends TestCase
         $this->assertFalse($body->isReadable());
     }
 
-    public function testSendResponseClosesStreamingResponseAndSendsResponseWithNoHeadersAndBodyForNotModifiedResponse()
+    public function testSendResponseClosesStreamingResponseAndSendsResponseWithNoHeadersAndBodyForNotModifiedResponse(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -321,7 +321,7 @@ class SapiHandlerTest extends TestCase
         $this->assertFalse($body->isReadable());
     }
 
-    public function testSendResponseClosesStreamingResponseAndSendsResponseWithNoHeadersAndBodyForNoContentResponse()
+    public function testSendResponseClosesStreamingResponseAndSendsResponseWithNoHeadersAndBodyForNoContentResponse(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -340,7 +340,7 @@ class SapiHandlerTest extends TestCase
         $this->assertFalse($body->isReadable());
     }
 
-    public function testSendResponseSendsStreamingResponseWithNoHeadersAndBodyFromStreamDataAndNoBufferHeaderForNginxServer()
+    public function testSendResponseSendsStreamingResponseWithNoHeadersAndBodyFromStreamDataAndNoBufferHeaderForNginxServer(): void
     {
         if (headers_sent() || !function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test requires running phpunit with --stderr and Xdebug enabled');
@@ -361,7 +361,7 @@ class SapiHandlerTest extends TestCase
         $body->end('test');
     }
 
-    public function testLogPrintsMessageWithCurrentDateAndTime()
+    public function testLogPrintsMessageWithCurrentDateAndTime(): void
     {
         // 2021-01-29 12:22:01.717 Hello\n
         $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} Hello" . PHP_EOL . "$/");


### PR DESCRIPTION
This changeset improves any type definitions and updates the test environment to PHPStan level `max`. This builds on top of the initial PHPStan support added in #200 and now runs the maximum level supported without having to resort to a baseline. The changeset size seems reasonable and the PHPStan configuration ignores only a smaller number of errors for legacy PHP versions.

Builds on top of #200 and #199