### PR TITLE
Load environment variables from `$_ENV`, `$_SERVER` and `getenv()` if in thread-safe environment

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -296,7 +296,7 @@ class Container
 
     private function hasVariable(string $name): bool
     {
-        return (\is_array($this->container) && \array_key_exists($name, $this->container)) || (\is_string($_SERVER[$name] ?? null) && \preg_match('/^[A-Z][A-Z0-9_]+$/', $name));
+        return (\is_array($this->container) && \array_key_exists($name, $this->container)) || (isset($_ENV[$name]) || (\is_string($_SERVER[$name] ?? null)) && \preg_match('/^[A-Z][A-Z0-9_]+$/', $name));
     }
 
     /**
@@ -329,6 +329,9 @@ class Container
             $this->container[$name] = $value;
         } elseif (\is_array($this->container) && \array_key_exists($name, $this->container)) {
             $value = $this->container[$name];
+        } elseif (isset($_ENV[$name])) {
+            assert(\is_string($_ENV[$name]));
+            $value = $_ENV[$name];
         } else {
             assert(\is_string($_SERVER[$name] ?? null));
             $value = $_SERVER[$name];

--- a/src/Container.php
+++ b/src/Container.php
@@ -98,12 +98,12 @@ class Container
     {
         assert(\preg_match('/^[A-Z][A-Z0-9_]+$/', $name) === 1);
 
-        if (\is_array($this->container) && \array_key_exists($name, $this->container)) {
-            $value = $this->loadVariable($name, 'mixed', true, 64);
-        } elseif ($this->container instanceof ContainerInterface && $this->container->has($name)) {
+        if ($this->container instanceof ContainerInterface && $this->container->has($name)) {
             $value = $this->container->get($name);
+        } elseif ($this->hasVariable($name)) {
+            $value = $this->loadVariable($name, 'mixed', true, 64);
         } else {
-            $value = $_SERVER[$name] ?? null;
+            return null;
         }
 
         if (!\is_string($value) && $value !== null) {
@@ -257,7 +257,7 @@ class Container
 
         // load container variables if parameter name is known
         assert($type === null || $type instanceof \ReflectionNamedType);
-        if ($allowVariables && (\array_key_exists($parameter->getName(), $this->container) || (isset($_SERVER[$parameter->getName()]) && \preg_match('/^[A-Z][A-Z0-9_]+$/', $parameter->getName())))) {
+        if ($allowVariables && $this->hasVariable($parameter->getName())) {
             return $this->loadVariable($parameter->getName(), $type === null ? 'mixed' : $type->getName(), $parameter->allowsNull(), $depth);
         }
 
@@ -294,15 +294,21 @@ class Container
         return $this->loadObject($type->getName(), $depth - 1);
     }
 
+    private function hasVariable(string $name): bool
+    {
+        return (\is_array($this->container) && \array_key_exists($name, $this->container)) || (\is_string($_SERVER[$name] ?? null) && \preg_match('/^[A-Z][A-Z0-9_]+$/', $name));
+    }
+
     /**
      * @return object|string|int|float|bool|null
      * @throws \BadMethodCallException if $name is not a valid container variable
      */
     private function loadVariable(string $name, string $type, bool $nullable, int $depth) /*: object|string|int|float|bool|null (PHP 8.0+) */
     {
-        assert(\is_array($this->container) && (\array_key_exists($name, $this->container) || isset($_SERVER[$name])));
+        assert($this->hasVariable($name));
+        assert(\is_array($this->container) || !$this->container->has($name));
 
-        if (($this->container[$name] ?? null) instanceof \Closure) {
+        if (\is_array($this->container) && ($this->container[$name] ?? null) instanceof \Closure) {
             if ($depth < 1) {
                 throw new \BadMethodCallException('Container variable $' . $name . ' is recursive');
             }
@@ -321,10 +327,10 @@ class Container
             }
 
             $this->container[$name] = $value;
-        } elseif (\array_key_exists($name, $this->container)) {
+        } elseif (\is_array($this->container) && \array_key_exists($name, $this->container)) {
             $value = $this->container[$name];
         } else {
-            assert(isset($_SERVER[$name]) && \is_string($_SERVER[$name]));
+            assert(\is_string($_SERVER[$name] ?? null));
             $value = $_SERVER[$name];
         }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2061,6 +2061,17 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $ret);
     }
 
+    public function testGetEnvReturnsStringFromProcessEnvIfNotSetInMap(): void
+    {
+        $container = new Container([]);
+
+        putenv('X_FOO=bar');
+        $ret = $container->getEnv('X_FOO');
+        putenv('X_FOO');
+
+        $this->assertEquals('bar', $ret);
+    }
+
     public function testGetEnvReturnsStringFromGlobalEnvBeforeServerIfNotSetInMap(): void
     {
         $container = new Container([]);
@@ -2069,6 +2080,19 @@ class ContainerTest extends TestCase
         $_SERVER['X_FOO'] = 'bar';
         $ret = $container->getEnv('X_FOO');
         unset($_ENV['X_FOO'], $_SERVER['X_FOO']);
+
+        $this->assertEquals('foo', $ret);
+    }
+
+    public function testGetEnvReturnsStringFromGlobalEnvBeforeProcessEnvIfNotSetInMap(): void
+    {
+        $container = new Container([]);
+
+        $_ENV['X_FOO'] = 'foo';
+        putenv('X_FOO=bar');
+        $ret = $container->getEnv('X_FOO');
+        unset($_ENV['X_FOO']);
+        putenv('X_FOO');
 
         $this->assertEquals('foo', $ret);
     }
@@ -2095,6 +2119,22 @@ class ContainerTest extends TestCase
         $container = new Container($psr);
 
         $this->assertNull($container->getEnv('X_FOO'));
+    }
+
+    public function testGetEnvReturnsStringFromProcessEnvIfPsrContainerHasNoEntry(): void
+    {
+        $psr = $this->createMock(ContainerInterface::class);
+        $psr->expects($this->atLeastOnce())->method('has')->with('X_FOO')->willReturn(false);
+        $psr->expects($this->never())->method('get');
+
+        assert($psr instanceof ContainerInterface);
+        $container = new Container($psr);
+
+        putenv('X_FOO=bar');
+        $ret = $container->getEnv('X_FOO');
+        putenv('X_FOO');
+
+        $this->assertEquals('bar', $ret);
     }
 
     public function testGetEnvReturnsStringFromGlobalEnvIfPsrContainerHasNoEntry(): void
@@ -2142,6 +2182,24 @@ class ContainerTest extends TestCase
         $_SERVER['X_FOO'] = 'bar';
         $ret = $container->getEnv('X_FOO');
         unset($_ENV['X_FOO'], $_SERVER['X_FOO']);
+
+        $this->assertEquals('foo', $ret);
+    }
+
+    public function testGetEnvReturnsStringFromGlobalEnvBeforeProcessEnvIfPsrContainerHasNoEntry(): void
+    {
+        $psr = $this->createMock(ContainerInterface::class);
+        $psr->expects($this->atLeastOnce())->method('has')->with('X_FOO')->willReturn(false);
+        $psr->expects($this->never())->method('get');
+
+        assert($psr instanceof ContainerInterface);
+        $container = new Container($psr);
+
+        $_ENV['X_FOO'] = 'foo';
+        putenv('X_FOO=bar');
+        $ret = $container->getEnv('X_FOO');
+        unset($_ENV['X_FOO']);
+        putenv('X_FOO');
 
         $this->assertEquals('foo', $ret);
     }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2077,7 +2077,7 @@ class ContainerTest extends TestCase
     public function testGetEnvReturnsStringFromGlobalServerIfPsrContainerHasNoEntry(): void
     {
         $psr = $this->createMock(ContainerInterface::class);
-        $psr->expects($this->once())->method('has')->with('X_FOO')->willReturn(false);
+        $psr->expects($this->atLeastOnce())->method('has')->with('X_FOO')->willReturn(false);
         $psr->expects($this->never())->method('get');
 
         assert($psr instanceof ContainerInterface);

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2039,6 +2039,17 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $container->getEnv('X_FOO'));
     }
 
+    public function testGetEnvReturnsStringFromGlobalEnvIfNotSetInMap(): void
+    {
+        $container = new Container([]);
+
+        $_ENV['X_FOO'] = 'bar';
+        $ret = $container->getEnv('X_FOO');
+        unset($_ENV['X_FOO']);
+
+        $this->assertEquals('bar', $ret);
+    }
+
     public function testGetEnvReturnsStringFromGlobalServerIfNotSetInMap(): void
     {
         $container = new Container([]);
@@ -2048,6 +2059,18 @@ class ContainerTest extends TestCase
         unset($_SERVER['X_FOO']);
 
         $this->assertEquals('bar', $ret);
+    }
+
+    public function testGetEnvReturnsStringFromGlobalEnvBeforeServerIfNotSetInMap(): void
+    {
+        $container = new Container([]);
+
+        $_ENV['X_FOO'] = 'foo';
+        $_SERVER['X_FOO'] = 'bar';
+        $ret = $container->getEnv('X_FOO');
+        unset($_ENV['X_FOO'], $_SERVER['X_FOO']);
+
+        $this->assertEquals('foo', $ret);
     }
 
     public function testGetEnvReturnsStringFromPsrContainer(): void
@@ -2074,6 +2097,22 @@ class ContainerTest extends TestCase
         $this->assertNull($container->getEnv('X_FOO'));
     }
 
+    public function testGetEnvReturnsStringFromGlobalEnvIfPsrContainerHasNoEntry(): void
+    {
+        $psr = $this->createMock(ContainerInterface::class);
+        $psr->expects($this->atLeastOnce())->method('has')->with('X_FOO')->willReturn(false);
+        $psr->expects($this->never())->method('get');
+
+        assert($psr instanceof ContainerInterface);
+        $container = new Container($psr);
+
+        $_ENV['X_FOO'] = 'bar';
+        $ret = $container->getEnv('X_FOO');
+        unset($_ENV['X_FOO']);
+
+        $this->assertEquals('bar', $ret);
+    }
+
     public function testGetEnvReturnsStringFromGlobalServerIfPsrContainerHasNoEntry(): void
     {
         $psr = $this->createMock(ContainerInterface::class);
@@ -2088,6 +2127,23 @@ class ContainerTest extends TestCase
         unset($_SERVER['X_FOO']);
 
         $this->assertEquals('bar', $ret);
+    }
+
+    public function testGetEnvReturnsStringFromGlobalEnvBeforeServerIfPsrContainerHasNoEntry(): void
+    {
+        $psr = $this->createMock(ContainerInterface::class);
+        $psr->expects($this->atLeastOnce())->method('has')->with('X_FOO')->willReturn(false);
+        $psr->expects($this->never())->method('get');
+
+        assert($psr instanceof ContainerInterface);
+        $container = new Container($psr);
+
+        $_ENV['X_FOO'] = 'foo';
+        $_SERVER['X_FOO'] = 'bar';
+        $ret = $container->getEnv('X_FOO');
+        unset($_ENV['X_FOO'], $_SERVER['X_FOO']);
+
+        $this->assertEquals('foo', $ret);
     }
 
     public function testGetEnvThrowsIfMapContainsInvalidType(): void


### PR DESCRIPTION
This changeset adds support for loading environment variables from the DI container configuration from `$_ENV`, `$_SERVER` and `getenv()` if in a thread-safe environment:

```php title="public/index.php"

<?php

require __DIR__ . '/../vendor/autoload.php';

$container = new FrameworkX\Container([
    React\MySQL\ConnectionInterface::class => function (string $DB_HOST = 'localhost', string $DB_USER = 'root', string $DB_PASS = '', string $DB_NAME = 'acme') {
        // connect to database defined in optional $DB_* environment variables
        $uri = 'mysql://' . $DB_USER . ':' . rawurlencode($DB_PASS) . '@' . $DB_HOST . '/' . $DB_NAME . '?idle=0.001';
        return (new React\MySQL\Factory())->createLazyConnection($uri);
    }
]);

$app = new FrameworkX\App($container);

// …
```

The previous version only supported explicit configuration of container variables and automatically loading environment variables from `$_SERVER` only. The updated version will now also load environment variables from `$_ENV` and `getenv()` if executed in a thread-safe environment.

* The [`$_ENV` superglobal](https://www.php.net/manual/en/reserved.variables.environment.php) will only contain the environment variables when [`variables_order`](https://www.php.net/manual/en/ini.core.php#ini.variables-order) includes `E` (the default in PHP, but disabled by default in Debian/Ubuntu-based distributions). Accordingly, this is commonly an empty array.
* The [`$_SERVER` superglobal](https://www.php.net/manual/en/reserved.variables.server.php) will only contain the environment variables in CLI and CGI/FastCGI environment and when [`variables_order`](https://www.php.net/manual/en/ini.core.php#ini.variables-order) includes `S` (the default). Most notably, this will not contain any environment variables for PHP's development web server.
* The [`getenv()` function](https://www.php.net/manual/en/function.getenv.php) (and `putenv()`) can be used to read from the process environment. This work across all environments, but may exhibit unsafe behavior and leak environment variables from other threads if executed in a threaded environment (such as when running as a multithreaded Apache module). Accordingly, we will only fall back to this method when PHP is not compiled with thread safety (NTS, which is the default and means it can not safely be used in a threaded environment anyway) or when used in an environment that does not leverage multithreading to handle parallel requests (ZTS used in CLI or CGI/FastCGI). Most notably, this will now be used as a fall back for PHP's development web server.

As a result, automatically loading environment variables from the `Container` will now "just work" across all environments. Considering the above logic, the resulting code appears relatively straightforward. Together with this analysis and multiple tries, you're looking at several days worth of work, enjoy!

Builds on top of #184 and #91.
Refs #200, #201 and #204.
Also refs #101 as this is the next big step in adding better configuration support and support for environment variables and `.env` (dotenv) files in the future.