### PR TITLE
Increase sleep time to cover test case for inaccurate clocks

### DIFF
--- a/tests/AccessLogHandlerTest.php
+++ b/tests/AccessLogHandlerTest.php
@@ -184,7 +184,7 @@ class AccessLogHandlerTest extends TestCase
         $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} 127\.0\.0\.1 \"GET \/users HTTP\/1\.1\" 200 0 0\.1\d\d" . PHP_EOL . "$/");
         $handler($request, function () use ($response) { return $response; });
 
-        usleep(110000); // 100ms + 10ms to account for inaccurate clocks
+        usleep(150000); // 100ms + 50ms to account for inaccurate clocks
         $stream->end();
     }
 


### PR DESCRIPTION
Over time we recognized failing tests because of an incorrect time measurement in our tests which mostly occurred when running our test suite under windows. Last seen here: https://github.com/clue/framework-x/actions/runs/3741602828/jobs/6351445435

I raised the sleep-time inside the responsible test to avoid any future tests failing because of inaccurate clocks.