### PR TITLE
Update test environment to PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "1.9.2 || 1.4.10",
-        "phpunit/phpunit": "^9.5 || ^7.5",
+        "phpunit/phpunit": "^10 || ^9.5 || ^7.5",
         "psr/container": "^2 || ^1"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.5+ -->
+<!-- PHPUnit configuration file with new format for current PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResult="false"
-         colors="true"
-         convertDeprecationsToExceptions="true">
+         colors="true">
     <testsuites>
         <testsuite name="Framework X test suite">
             <directory>./tests/</directory>
@@ -21,7 +20,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
-        <!-- <ini name="zend.assertions=1" value="1" /> -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
         <ini name="assert.active" value="1" />
         <ini name="assert.exception" value="1" />
         <ini name="assert.bail" value="0" />

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with old PHPUnit 7 format for PHP < 7.3 -->
+<!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
@@ -19,7 +19,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
-        <!-- <ini name="zend.assertions=1" value="1" /> -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
         <ini name="assert.active" value="1" />
         <ini name="assert.exception" value="1" />
         <ini name="assert.bail" value="0" />

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1902,7 +1902,7 @@ class AppTest extends TestCase
         $this->assertStringMatchesFormat("%a<p>Expected request handler to return <code>Psr\Http\Message\ResponseInterface</code> but got uncaught <code>BadMethodCallException</code> with message <code>Request handler class UnknownClass not found</code> in <code title=\"See %s\">Container.php:%d</code>.</p>\n%a", (string) $response->getBody());
     }
 
-    public function provideInvalidClasses(): \Generator
+    public static function provideInvalidClasses(): \Generator
     {
         yield [
             InvalidConstructorPrivate::class,

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -567,7 +567,7 @@ class ContainerTest extends TestCase
     }
 
     /** @return list<list<\stdClass|string|null>> */
-    public function provideMixedValue(): array
+    public static function provideMixedValue(): array
     {
         return [
             [

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -387,7 +387,7 @@ class ErrorHandlerTest extends TestCase
     }
 
     /** @return list<list<string>> */
-    public function provideExceptionMessage(): array
+    public static function provideExceptionMessage(): array
     {
         return [
             [
@@ -459,7 +459,7 @@ class ErrorHandlerTest extends TestCase
     }
 
     /** @return list<list<mixed>> */
-    public function provideInvalidReturnValue(): array
+    public static function provideInvalidReturnValue(): array
     {
         return [
             [

--- a/tests/Io/HtmlHandlerTest.php
+++ b/tests/Io/HtmlHandlerTest.php
@@ -20,7 +20,7 @@ class HtmlHandlerTest extends TestCase
     }
 
     /** @return list<list<string>> */
-    public function provideNames(): array
+    public static function provideNames(): array
     {
         return [
             [


### PR DESCRIPTION
PHPUnit 10 has been released (yesterday) 🎉 Time to update our test suite to take advantage of the latest PHPUnit version on supported PHP versions (PHP 8.1+). All preparations have already landed in previous PRs linked below, so this update was really smooth sailing.

Builds on top of #207, #194, #199 and others