### PR TITLE
Fixed Set-Cookie bug

### DIFF
--- a/src/Io/SapiHandler.php
+++ b/src/Io/SapiHandler.php
@@ -108,7 +108,7 @@ class SapiHandler
         ini_set('default_charset', '');
         foreach ($response->getHeaders() as $name => $values) {
             foreach ($values as $value) {
-                header($name . ': ' . $value);
+                header($name . ': ' . $value, false);
             }
         }
         ini_set('default_charset', $old);


### PR DESCRIPTION
By default, header() overwrites previous headers with the same name. This means only the last of multiple cookies was actually set. $replace set to false avoids this unexpected behavior.