### PR TITLE
Refactor logging into new `LogStreamHandler`

### DIFF
--- a/src/Io/LogStreamHandler.php
+++ b/src/Io/LogStreamHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace FrameworkX\Io;
+
+/**
+ * @internal
+ */
+class LogStreamHandler
+{
+    /** @var resource */
+    private $stream;
+
+    /** @throws \RuntimeException if given `$path` can not be opened in append mode */
+    public function __construct(string $path)
+    {
+        $errstr = '';
+        \set_error_handler(function (int $_, string $error) use (&$errstr): bool {
+            // Match errstr from PHP's warning message.
+            // fopen(/dev/not-a-valid-path): Failed to open stream: Permission denied
+            $errstr = \preg_replace('#.*: #', '', $error);
+
+            return true;
+        });
+
+        $stream = \fopen($path, 'ae');
+        \restore_error_handler();
+
+        if ($stream === false) {
+            throw new \RuntimeException(
+                'Unable to open log file "' . $path . '": ' . $errstr
+            );
+        }
+
+        $this->stream = $stream;
+    }
+
+    public function log(string $message): void
+    {
+        $time = \microtime(true);
+        $prefix = \date('Y-m-d H:i:s', (int) $time) . \sprintf('.%03d ', (int) (($time - (int) $time) * 1e3));
+
+        $ret = \fwrite($this->stream, $prefix . $message . \PHP_EOL);
+        assert(\is_int($ret));
+    }
+}

--- a/src/Io/SapiHandler.php
+++ b/src/Io/SapiHandler.php
@@ -13,15 +13,6 @@ use React\Stream\ReadableStreamInterface;
  */
 class SapiHandler
 {
-    /** @var resource */
-    private $logStream;
-
-    public function __construct()
-    {
-        // @phpstan-ignore-next-line because `fopen()` is known to always return a `resource` for built-in wrappers
-        $this->logStream = PHP_SAPI === 'cli' ? \fopen('php://output', 'a') : (\defined('STDERR') ? \STDERR : \fopen('php://stderr', 'a'));
-    }
-
     public function requestFromGlobals(): ServerRequestInterface
     {
         $host = null;
@@ -139,13 +130,5 @@ class SapiHandler
         } else {
             echo $body;
         }
-    }
-
-    public function log(string $message): void
-    {
-        $time = microtime(true);
-        $log = date('Y-m-d H:i:s', (int)$time) . sprintf('.%03d ', (int)(($time - (int)$time) * 1e3)) . $message . PHP_EOL;
-
-        fwrite($this->logStream, $log);
     }
 }

--- a/tests/Io/LogStreamHandlerTest.php
+++ b/tests/Io/LogStreamHandlerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Framework\Tests\Io;
+
+use FrameworkX\Io\LogStreamHandler;
+use PHPUnit\Framework\TestCase;
+
+class LogStreamHandlerTest extends TestCase
+{
+    public function testLogWithMemoryStreamWritesMessageWithCurrentDateAndTime(): void
+    {
+        $logger = new LogStreamHandler('php://memory');
+
+        $logger->log('Hello');
+
+        $ref = new \ReflectionProperty($logger, 'stream');
+        $ref->setAccessible(true);
+        $stream = $ref->getValue($logger);
+        assert(is_resource($stream));
+
+        rewind($stream);
+        $output = stream_get_contents($stream);
+        assert(is_string($output));
+
+        // 2021-01-29 12:22:01.717 Hello\n
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} Hello" . PHP_EOL . "$/", $output); // @phpstan-ignore-line
+        } else {
+            // legacy PHPUnit < 9.1
+            $this->assertRegExp("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} Hello" . PHP_EOL . "$/", $output);
+        }
+    }
+
+    public function testLogWithOutputStreamPrintsMessageWithCurrentDateAndTime(): void
+    {
+        $logger = new LogStreamHandler('php://output');
+
+        // 2021-01-29 12:22:01.717 Hello\n
+        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} Hello" . PHP_EOL . "$/");
+        $logger->log('Hello');
+    }
+
+    public function testCtorWithDirectoryInsteadOfFileThrowsWithoutCallingGlobalErrorHandler(): void
+    {
+        $called = 0;
+        set_error_handler($new = function () use (&$called): bool {
+            ++$called;
+            return false;
+        });
+
+        try {
+            try {
+                new LogStreamHandler(__DIR__);
+            } finally {
+                $previous = set_error_handler(function (): bool { return false; });
+                restore_error_handler();
+                restore_error_handler();
+            }
+            $this->fail();
+        } catch (\RuntimeException $e) {
+            $errstr = DIRECTORY_SEPARATOR === '\\' ? 'Permission denied' : 'Is a directory';
+            $this->assertEquals('Unable to open log file "' . __DIR__ . '": ' . $errstr, $e->getMessage());
+
+            $this->assertEquals(0, $called);
+            $this->assertSame($new, $previous ?? null);
+        }
+    }
+}

--- a/tests/Io/SapiHandlerTest.php
+++ b/tests/Io/SapiHandlerTest.php
@@ -379,13 +379,4 @@ class SapiHandlerTest extends TestCase
 
         $this->assertEquals(['Content-Type:', 'Set-Cookie: 1=1', 'Set-Cookie: 2=2'], xdebug_get_headers());
     }
-
-    public function testLogPrintsMessageWithCurrentDateAndTime(): void
-    {
-        // 2021-01-29 12:22:01.717 Hello\n
-        $this->expectOutputRegex("/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} Hello" . PHP_EOL . "$/");
-
-        $sapi = new SapiHandler();
-        $sapi->log('Hello');
-    }
 }


### PR DESCRIPTION
This changeset refactors logging into a new internal `LogStreamHandler`. This should not otherwise affect the public APIs or outside behavior in any way.

This is a starting point to add more options to control access logging in follow-up PRs as discussed in #169.

Builds on top of #221, #174, #44 and others
Also refs https://github.com/sebastianbergmann/phpunit/issues/4086