### PR TITLE
Refactor reactive server logic into new `ReactiveHandler`

### DIFF
--- a/src/Io/ReactiveHandler.php
+++ b/src/Io/ReactiveHandler.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace FrameworkX\Io;
+
+use React\EventLoop\Loop;
+use React\Http\HttpServer;
+use React\Socket\SocketServer;
+
+/**
+ * [Internal] Powerful reactive request handler built on top of ReactPHP.
+ *
+ * This is where the magic happens: The main `App` uses this class to run
+ * ReactPHP's efficient HTTP server to handle incoming HTTP requests when
+ * executed on the command line (CLI). ReactPHP's lightweight socket server can
+ * listen for a large number of concurrent connections and process multiple
+ * incoming connections simultaneously. The long-running server process will
+ * continue to run until it is interrupted by a signal.
+ *
+ * Note that this is an internal class only and nothing you should usually have
+ * to care about. See also the `App` and `SapiHandler` for more details.
+ *
+ * @internal
+ */
+class ReactiveHandler
+{
+    /** @var LogStreamHandler */
+    private $logger;
+
+    /** @var string */
+    private $listenAddress;
+
+    public function __construct(?string $listenAddress)
+    {
+        /** @throws void */
+        $this->logger = new LogStreamHandler('php://output');
+        $this->listenAddress = $listenAddress ?? '127.0.0.1:8080';
+    }
+
+    public function run(callable $handler): void
+    {
+        $socket = new SocketServer($this->listenAddress);
+
+        $http = new HttpServer($handler);
+        $http->listen($socket);
+
+        $logger = $this->logger;
+        $logger->log('Listening on ' . \str_replace('tcp:', 'http:', (string) $socket->getAddress()));
+
+        $http->on('error', static function (\Exception $e) use ($logger): void {
+            $logger->log('HTTP error: ' . $e->getMessage());
+        });
+
+        // @codeCoverageIgnoreStart
+        try {
+            Loop::addSignal(\defined('SIGINT') ? \SIGINT : 2, $f1 = static function () use ($socket, $logger): void {
+                if (\PHP_VERSION_ID >= 70200 && \stream_isatty(\STDIN)) {
+                    echo "\r";
+                }
+                $logger->log('Received SIGINT, stopping loop');
+
+                $socket->close();
+                Loop::stop();
+            });
+            Loop::addSignal(\defined('SIGTERM') ? \SIGTERM : 15, $f2 = static function () use ($socket, $logger): void {
+                $logger->log('Received SIGTERM, stopping loop');
+
+                $socket->close();
+                Loop::stop();
+            });
+        } catch (\BadMethodCallException $e) {
+            $logger->log('Notice: No signal handler support, installing ext-ev or ext-pcntl recommended for production use.');
+        }
+        // @codeCoverageIgnoreEnd
+
+        do {
+            Loop::run();
+
+            if ($socket->getAddress() !== null) {
+                // Fiber compatibility mode for PHP < 8.1: Restart loop as long as socket is available
+                $logger->log('Warning: Loop restarted. Upgrade to react/async v4 recommended for production use.');
+            } else {
+                break;
+            }
+        } while (true);
+
+        // remove signal handlers when loop stops (if registered)
+        Loop::removeSignal(\defined('SIGINT') ? \SIGINT : 2, $f1 ?? 'printf');
+        Loop::removeSignal(\defined('SIGTERM') ? \SIGTERM : 15, $f2 ?? 'printf');
+    }
+}

--- a/tests/Io/ReactiveHandlerTest.php
+++ b/tests/Io/ReactiveHandlerTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace FrameworkX\Tests\Io;
+
+use FrameworkX\Io\LogStreamHandler;
+use FrameworkX\Io\ReactiveHandler;
+use PHPUnit\Framework\TestCase;
+use React\EventLoop\Loop;
+use React\Http\Message\Response;
+use React\Socket\ConnectionInterface;
+use React\Socket\Connector;
+
+class ReactiveHandlerTest extends TestCase
+{
+    public function testRunWillReportDefaultListeningAddressAndRunLoop(): void
+    {
+        $socket = @stream_socket_server('127.0.0.1:8080');
+        if ($socket === false) {
+            $this->markTestSkipped('Listen address :8080 already in use');
+        }
+        assert(is_resource($socket));
+        fclose($socket);
+
+        $handler = new ReactiveHandler(null);
+
+        $logger = $this->createMock(LogStreamHandler::class);
+        $logger->expects($this->atLeastOnce())->method('log')->withConsecutive(['Listening on http://127.0.0.1:8080']);
+
+        // $handler->logger = $logger;
+        $ref = new \ReflectionProperty($handler, 'logger');
+        $ref->setAccessible(true);
+        $ref->setValue($handler, $logger);
+
+        // lovely: remove socket server on next tick to terminate loop
+        Loop::futureTick(function () {
+            $resources = get_resources();
+            $socket = end($resources);
+            assert(is_resource($socket));
+
+            Loop::removeReadStream($socket);
+            fclose($socket);
+
+            Loop::stop();
+        });
+
+        $handler->run(function (): void { });
+    }
+
+    public function testRunWillReportGivenListeningAddressAndRunLoop(): void
+    {
+        $socket = stream_socket_server('127.0.0.1:0');
+        assert(is_resource($socket));
+        $addr = stream_socket_get_name($socket, false);
+        assert(is_string($addr));
+        fclose($socket);
+
+        $handler = new ReactiveHandler($addr);
+
+        $logger = $this->createMock(LogStreamHandler::class);
+        $logger->expects($this->atLeastOnce())->method('log')->withConsecutive(['Listening on http://' . $addr]);
+
+        // $handler->logger = $logger;
+        $ref = new \ReflectionProperty($handler, 'logger');
+        $ref->setAccessible(true);
+        $ref->setValue($handler, $logger);
+
+        // lovely: remove socket server on next tick to terminate loop
+        Loop::futureTick(function () {
+            $resources = get_resources();
+            $socket = end($resources);
+            assert(is_resource($socket));
+
+            Loop::removeReadStream($socket);
+            fclose($socket);
+
+            Loop::stop();
+        });
+
+        $handler->run(function (): void { });
+    }
+
+    public function testRunWillReportGivenListeningAddressWithRandomPortAndRunLoop(): void
+    {
+        $handler = new ReactiveHandler('127.0.0.1:0');
+
+        $logger = $this->createMock(LogStreamHandler::class);
+        $logger->expects($this->atLeastOnce())->method('log')->withConsecutive([$this->matches('Listening on http://127.0.0.1:%d')]);
+
+        // $handler->logger = $logger;
+        $ref = new \ReflectionProperty($handler, 'logger');
+        $ref->setAccessible(true);
+        $ref->setValue($handler, $logger);
+
+        // lovely: remove socket server on next tick to terminate loop
+        Loop::futureTick(function () {
+            $resources = get_resources();
+            $socket = end($resources);
+            assert(is_resource($socket));
+
+            Loop::removeReadStream($socket);
+            fclose($socket);
+
+            Loop::stop();
+        });
+
+        $handler->run(function (): void { });
+    }
+
+    public function testRunWillRestartLoopUntilSocketIsClosed(): void
+    {
+        $handler = new ReactiveHandler('127.0.0.1:0');
+
+        $logger = $this->createMock(LogStreamHandler::class);
+
+        // $handler->logger = $logger;
+        $ref = new \ReflectionProperty($handler, 'logger');
+        $ref->setAccessible(true);
+        $ref->setValue($handler, $logger);
+
+        // lovely: remove socket server on next tick to terminate loop
+        Loop::futureTick(function () use ($logger) {
+            $resources = get_resources();
+            $socket = end($resources);
+            assert(is_resource($socket));
+
+            Loop::futureTick(function () use ($socket) {
+                Loop::removeReadStream($socket);
+                fclose($socket);
+
+                Loop::stop();
+            });
+
+            $logger->expects($this->once())->method('log')->with('Warning: Loop restarted. Upgrade to react/async v4 recommended for production use.');
+            Loop::stop();
+        });
+
+        $handler->run(function (): void { });
+    }
+
+    public function testRunWillListenForHttpRequestAndSendBackHttpResponseOverSocket(): void
+    {
+        $socket = stream_socket_server('127.0.0.1:0');
+        assert(is_resource($socket));
+        $addr = stream_socket_get_name($socket, false);
+        assert(is_string($addr));
+        fclose($socket);
+
+        $handler = new ReactiveHandler($addr);
+
+        $logger = $this->createMock(LogStreamHandler::class);
+
+        // $handler->logger = $logger;
+        $ref = new \ReflectionProperty($handler, 'logger');
+        $ref->setAccessible(true);
+        $ref->setValue($handler, $logger);
+
+        Loop::futureTick(function () use ($addr): void {
+            $connector = new Connector();
+            $connector->connect($addr)->then(function (ConnectionInterface $connection): void {
+                $connection->on('data', function (string $data): void {
+                    $this->assertEquals("HTTP/1.0 200 OK\r\nContent-Length: 3\r\n\r\nOK\n", $data);
+                });
+
+                // lovely: remove socket server on client connection close to terminate loop
+                $connection->on('close', function (): void {
+                    $resources = get_resources();
+                    end($resources);
+                    prev($resources);
+                    $socket = prev($resources);
+                    assert(is_resource($socket));
+
+                    Loop::removeReadStream($socket);
+                    fclose($socket);
+
+                    Loop::stop();
+                });
+
+                $connection->write("GET /unknown HTTP/1.0\r\nHost: localhost\r\n\r\n");
+            });
+        });
+
+        $handler->run(function (): Response {
+            return new Response(200, ['Date' => '', 'Server' => ''], "OK\n");
+        });
+    }
+
+    public function testRunWillReportHttpErrorForInvalidClientRequest(): void
+    {
+        $socket = stream_socket_server('127.0.0.1:0');
+        assert(is_resource($socket));
+        $addr = stream_socket_get_name($socket, false);
+        assert(is_string($addr));
+        fclose($socket);
+
+        $handler = new ReactiveHandler($addr);
+
+        $logger = $this->createMock(LogStreamHandler::class);
+
+        // $handler->logger = $logger;
+        $ref = new \ReflectionProperty($handler, 'logger');
+        $ref->setAccessible(true);
+        $ref->setValue($handler, $logger);
+
+        Loop::futureTick(function () use ($addr, $logger): void {
+            $connector = new Connector();
+            $connector->connect($addr)->then(function (ConnectionInterface $connection) use ($logger): void {
+                $logger->expects($this->once())->method('log')->with($this->matchesRegularExpression('/^HTTP error: .*$/'));
+                $connection->write("not a valid HTTP request\r\n\r\n");
+
+                // lovely: remove socket server on client connection close to terminate loop
+                $connection->on('close', function (): void {
+                    $resources = get_resources();
+                    end($resources);
+                    prev($resources);
+                    $socket = prev($resources);
+                    assert(is_resource($socket));
+
+                    Loop::removeReadStream($socket);
+                    fclose($socket);
+
+                    Loop::stop();
+                });
+            });
+        });
+
+        $handler->run(function (): void { });
+    }
+
+    /**
+     * @requires function pcntl_signal
+     * @requires function posix_kill
+     */
+    public function testRunWillStopWhenReceivingSigint(): void
+    {
+        $handler = new ReactiveHandler('127.0.0.1:0');
+
+        $logger = $this->createMock(LogStreamHandler::class);
+        $logger->expects($this->exactly(2))->method('log');
+
+        // $handler->logger = $logger;
+        $ref = new \ReflectionProperty($handler, 'logger');
+        $ref->setAccessible(true);
+        $ref->setValue($handler, $logger);
+
+        Loop::futureTick(function () use ($logger) {
+            $logger->expects($this->once())->method('log')->with('Received SIGINT, stopping loop');
+
+            $pid = getmypid();
+            assert(is_int($pid));
+            posix_kill($pid, defined('SIGINT') ? SIGINT : 2);
+        });
+
+        $this->expectOutputRegex("#^\r?$#");
+        $handler->run(function (): void { });
+    }
+
+    /**
+     * @requires function pcntl_signal
+     * @requires function posix_kill
+     */
+    public function testRunWillStopWhenReceivingSigterm(): void
+    {
+        $handler = new ReactiveHandler('127.0.0.1:0');
+
+        $logger = $this->createMock(LogStreamHandler::class);
+
+        // $handler->logger = $logger;
+        $ref = new \ReflectionProperty($handler, 'logger');
+        $ref->setAccessible(true);
+        $ref->setValue($handler, $logger);
+
+        Loop::futureTick(function () use ($logger) {
+            $logger->expects($this->once())->method('log')->with('Received SIGTERM, stopping loop');
+
+            $pid = getmypid();
+            assert(is_int($pid));
+            posix_kill($pid, defined('SIGTERM') ? SIGTERM : 15);
+        });
+
+        $handler->run(function (): void { });
+    }
+
+    public function testRunWithEmptyAddressThrows(): void
+    {
+        $handler = new ReactiveHandler('');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $handler->run(function (): void { });
+    }
+
+    public function testRunWithBusyPortThrows(): void
+    {
+        $socket = stream_socket_server('127.0.0.1:0');
+        assert(is_resource($socket));
+        $addr = stream_socket_get_name($socket, false);
+        assert(is_string($addr));
+
+        if (@stream_socket_server($addr) !== false) {
+            $this->markTestSkipped('System does not prevent listening on same address twice');
+        }
+
+        $handler = new ReactiveHandler($addr);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to listen on');
+        $handler->run(function (): void { });
+    }
+}


### PR DESCRIPTION
This changeset refactors the reactive server logic into a new internal `ReactiveHandler`. This should not otherwise affect the public APIs or outside behavior in any way.

This is a starting point to add more options to control the reactive server, application logging, access logging and more in follow-up PRs.

Builds on top of #222, #221, #44 and others