### PR TITLE
Improve performance by only using `FiberHandler` for `ReactiveHandler`

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -2,7 +2,6 @@
 
 namespace FrameworkX;
 
-use FrameworkX\Io\FiberHandler;
 use FrameworkX\Io\MiddlewareHandler;
 use FrameworkX\Io\ReactiveHandler;
 use FrameworkX\Io\RedirectHandler;
@@ -101,11 +100,6 @@ class App
         // only log for built-in webserver and PHP development webserver by default, others have their own access log
         if ($needsAccessLog instanceof Container) {
             \array_unshift($handlers, $needsAccessLog->getAccessLogHandler());
-        }
-
-        // automatically start new fiber for each request on PHP 8.1+
-        if (\PHP_VERSION_ID >= 80100) {
-            \array_unshift($handlers, new FiberHandler()); // @codeCoverageIgnore
         }
 
         $this->router = new RouteHandler($container);

--- a/src/Io/ReactiveHandler.php
+++ b/src/Io/ReactiveHandler.php
@@ -40,7 +40,8 @@ class ReactiveHandler
     {
         $socket = new SocketServer($this->listenAddress);
 
-        $http = new HttpServer($handler);
+        // create HTTP server, automatically start new fiber for each request on PHP 8.1+
+        $http = new HttpServer(...(\PHP_VERSION_ID >= 80100 ? [new FiberHandler(), $handler] : [$handler]));
         $http->listen($socket);
 
         $logger = $this->logger;

--- a/tests/AppMiddlewareTest.php
+++ b/tests/AppMiddlewareTest.php
@@ -4,7 +4,6 @@ namespace FrameworkX\Tests;
 
 use FrameworkX\AccessLogHandler;
 use FrameworkX\App;
-use FrameworkX\Io\FiberHandler;
 use FrameworkX\Io\MiddlewareHandler;
 use FrameworkX\Io\RouteHandler;
 use PHPUnit\Framework\TestCase;
@@ -686,16 +685,6 @@ class AppMiddlewareTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($middleware);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-
-            $next = array_shift($handlers);
-            $this->assertInstanceOf(AccessLogHandler::class, $next);
-
-            array_unshift($handlers, $next, $first);
-        }
 
         $first = array_shift($handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $first);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -6,7 +6,6 @@ use FrameworkX\AccessLogHandler;
 use FrameworkX\App;
 use FrameworkX\Container;
 use FrameworkX\ErrorHandler;
-use FrameworkX\Io\FiberHandler;
 use FrameworkX\Io\MiddlewareHandler;
 use FrameworkX\Io\ReactiveHandler;
 use FrameworkX\Io\RouteHandler;
@@ -52,11 +51,6 @@ class AppTest extends TestCase
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
-
         $this->assertCount(4, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
         $this->assertInstanceOf(ErrorHandler::class, $handlers[1]);
@@ -85,11 +79,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
 
         $this->assertCount(3, $handlers);
         $this->assertSame($accessLogHandler, $handlers[0]);
@@ -122,11 +111,6 @@ class AppTest extends TestCase
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
-
         $this->assertCount(4, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
         $this->assertInstanceOf(ErrorHandler::class, $handlers[1]);
@@ -155,11 +139,6 @@ class AppTest extends TestCase
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
-
         $this->assertCount(3, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
         $this->assertSame($errorHandler, $handlers[1]);
@@ -179,11 +158,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
 
         $this->assertCount(3, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
@@ -206,11 +180,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
 
         $this->assertCount(3, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
@@ -237,11 +206,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
 
         $this->assertCount(3, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
@@ -272,11 +236,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
 
         $this->assertCount(3, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
@@ -309,11 +268,6 @@ class AppTest extends TestCase
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
-
         $this->assertCount(4, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
         $this->assertSame($errorHandler, $handlers[1]);
@@ -337,11 +291,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
 
         $this->assertCount(5, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
@@ -382,11 +331,6 @@ class AppTest extends TestCase
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
-
         $this->assertCount(5, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
         $this->assertSame($errorHandler1, $handlers[1]);
@@ -412,11 +356,6 @@ class AppTest extends TestCase
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
-
         $this->assertCount(3, $handlers);
         $this->assertSame($accessLogHandler, $handlers[0]);
         $this->assertSame($errorHandler, $handlers[1]);
@@ -436,11 +375,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
 
         $this->assertCount(3, $handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $handlers[0]);
@@ -470,11 +404,6 @@ class AppTest extends TestCase
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
-
         $this->assertCount(3, $handlers);
         $this->assertSame($accessLogHandler, $handlers[0]);
         $this->assertSame($errorHandler, $handlers[1]);
@@ -498,11 +427,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
 
         $this->assertCount(5, $handlers);
         $this->assertInstanceOf(ErrorHandler::class, $handlers[0]);
@@ -539,11 +463,6 @@ class AppTest extends TestCase
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
-
         $this->assertCount(3, $handlers);
         $this->assertSame($accessLogHandler, $handlers[0]);
         $this->assertSame($errorHandler, $handlers[1]);
@@ -579,11 +498,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-        }
 
         $this->assertCount(4, $handlers);
         $this->assertSame($accessLogHandler, $handlers[0]);
@@ -1748,16 +1662,6 @@ class AppTest extends TestCase
         $ref->setAccessible(true);
         $handlers = $ref->getValue($middleware);
         assert(is_array($handlers));
-
-        if (PHP_VERSION_ID >= 80100) {
-            $first = array_shift($handlers);
-            $this->assertInstanceOf(FiberHandler::class, $first);
-
-            $next = array_shift($handlers);
-            $this->assertInstanceOf(AccessLogHandler::class, $next);
-
-            array_unshift($handlers, $next, $first);
-        }
 
         $first = array_shift($handlers);
         $this->assertInstanceOf(AccessLogHandler::class, $first);


### PR DESCRIPTION
This changeset improves performance by only using `FiberHandler` for `ReactiveHandler`. In particular, the traditional PHP SAPIs and the new `App::__invoke()` method do not need to start a fiber for each request.

On my machine, the `App::__invoke()` is now ~40% faster consistently (16s -> 10s for 1M invocations) and the PHP development web server is ~10% faster (2000rps -> 2200rps). The performance of the built-in web server is unchanged as expected (14000rps).

Besides performance improvements, this also allows us to clean up a number of now unneeded checks in the test suite and simplify quite a few tests a bit.

Builds on top of #236, #224, #128, #117 and others