### PR TITLE
Pass ErrorHandler to the RouteHandler.

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -101,8 +101,10 @@ class App
         if ($needsAccessLog instanceof Container) {
             \array_unshift($handlers, $needsAccessLog->getAccessLogHandler());
         }
-
-        $this->router = new RouteHandler($container);
+        $errorHandler = \array_reduce($handlers, function ($carry, $handler) {
+            return $carry ?? ($handler instanceof ErrorHandler ? $handler : null);
+        });
+        $this->router = new RouteHandler($container, $errorHandler);
         $handlers[] = $this->router;
         $this->handler = new MiddlewareHandler($handlers);
         $this->sapi = \PHP_SAPI === 'cli' ? new ReactiveHandler($container->getEnv('X_LISTEN')) : new SapiHandler();

--- a/src/Io/RouteHandler.php
+++ b/src/Io/RouteHandler.php
@@ -30,10 +30,10 @@ class RouteHandler
     /** @var Container */
     private $container;
 
-    public function __construct(Container $container = null)
+    public function __construct(Container $container = null, ErrorHandler $errorHandler = null)
     {
         $this->routeCollector = new RouteCollector(new RouteParser(), new RouteGenerator());
-        $this->errorHandler = new ErrorHandler();
+        $this->errorHandler = $errorHandler ?? new ErrorHandler();
         $this->container = $container ?? new Container();
     }
 


### PR DESCRIPTION
In order to response with individual error messages and / or formats (e.g. JSON), we are able to put an ErrorHandler to the container (see #175). But the individual ErrorHandler is not used in the RouteHandler. This PR allows to pass an ErrorHandler to the RouteHandler, and the App passes the selected ErrorHandler to the RouteHandler. This will allow to response with individual error messages and / or formats in case a route is not found.