### PR TITLE
add route group

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -25,6 +25,12 @@ class App
     /** @var ReactiveHandler|SapiHandler */
     private $sapi;
 
+    /** @var string */
+    protected $currentGroupPrefix;
+
+    /** @var array */
+    protected $currentGroupHandlers = [];
+
     /**
      * Instantiate new X application
      *
@@ -190,7 +196,33 @@ class App
      */
     public function any(string $route, $handler, ...$handlers): void
     {
-        $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $route, $handler, ...$handlers);
+        if (!empty($this->currentGroupHandlers)) {
+            \array_unshift($handlers, $handler);
+            $currentGroupHandlers = $this->currentGroupHandlers;
+            $handler = array_pop($currentGroupHandlers);
+            \array_unshift($handlers, ...$currentGroupHandlers);
+        }
+        $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $this->currentGroupPrefix . $route, $handler, ...$handlers);
+    }
+
+    /**
+     * Create a route group with a common prefix.
+     *
+     * All routes created in the passed callback will have the given group prefix prepended.
+     *
+     * @param string $prefix
+     * @param array $handlers
+     * @param callable $callback
+     */
+    public function addGroup($prefix, $handlers = [], callable $callback)
+    {
+        $previousGroupPrefix = $this->currentGroupPrefix;
+        $previousGroupHandlers = $this->currentGroupHandlers;
+        $this->currentGroupPrefix = $previousGroupPrefix . $prefix;
+        $this->currentGroupHandlers = array_merge($previousGroupHandlers, $handlers);
+        $callback($this);
+        $this->currentGroupPrefix = $previousGroupPrefix;
+        $this->currentGroupHandlers = $previousGroupHandlers;
     }
 
     /**
@@ -202,7 +234,13 @@ class App
      */
     public function map(array $methods, string $route, $handler, ...$handlers): void
     {
-        $this->router->map($methods, $route, $handler, ...$handlers);
+        if (!empty($this->currentGroupHandlers)) {
+            \array_unshift($handlers, $handler);
+            $currentGroupHandlers = $this->currentGroupHandlers;
+            $handler = array_pop($currentGroupHandlers);
+            \array_unshift($handlers, ...$currentGroupHandlers);
+        }
+        $this->router->map($methods, $this->currentGroupPrefix . $route, $handler, ...$handlers);
     }
 
     /**


### PR DESCRIPTION
can use addGroup 

```
       $app->addGroup('/users', [
            // middleware1,
            // middleware2
        ], function ($app) {
            $app->get('/{name}', function ($request) {
                return \React\Http\Message\Response::plaintext(
                    "Hello " . $request->getAttribute('name') . "!\n"
                );
            });
            $app->addGroup('/{name}/posts', [
                // middleware1,
                // middleware2
            ], function ($app) {
                $app->get('/{post}', function ($request) {
                    return \React\Http\Message\Response::plaintext(
                        "Hello User {$request->getAttribute('name')} Posts " . $request->getAttribute('post') . "!\n"
                    );
                });
            });
        });

        $app->addGroup('/posts', [
            // middleware1,
            // middleware2
        ], function ($app) {
            $app->get('/{post}', function ($request) {
                return \React\Http\Message\Response::plaintext(
                    "Hello Posts " . $request->getAttribute('post') . "!\n"
                );
            });
        });
```