### PR TITLE
Improve performance by skipping `AccessLogHandler` if it writes to `/dev/null`

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -80,7 +80,12 @@ class App
                     if ($needsErrorHandler && ($handler instanceof ErrorHandler || $handler instanceof AccessLogHandler) && !$handlers) {
                         $needsErrorHandler = null;
                     }
-                    $handlers[] = $handler;
+
+                    // only add to list of handlers if this is not a NOOP
+                    if (!$handler instanceof AccessLogHandler || !$handler->isDevNull()) {
+                        $handlers[] = $handler;
+                    }
+
                     if ($handler instanceof AccessLogHandler) {
                         $needsAccessLog = null;
                         $needsErrorHandlerNext = true;
@@ -99,7 +104,10 @@ class App
 
         // only log for built-in webserver and PHP development webserver by default, others have their own access log
         if ($needsAccessLog instanceof Container) {
-            \array_unshift($handlers, $needsAccessLog->getAccessLogHandler());
+            $handler = $needsAccessLog->getAccessLogHandler();
+            if (!$handler->isDevNull()) {
+                \array_unshift($handlers, $handler);
+            }
         }
 
         $this->router = new RouteHandler($container);

--- a/tests/AccessLogHandlerTest.php
+++ b/tests/AccessLogHandlerTest.php
@@ -36,6 +36,24 @@ class AccessLogHandlerTest extends TestCase
         unlink($path);
     }
 
+    public function testIsDevNullReturnsFalseForDefaultPath(): void
+    {
+        $handler = new AccessLogHandler();
+
+        $this->assertFalse($handler->isDevNull());
+    }
+
+    public function testIsDevNullReturnsTrueForDevNull(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Not supported on Windows');
+        }
+
+        $handler = new AccessLogHandler('/dev/null');
+
+        $this->assertTrue($handler->isDevNull());
+    }
+
     public function testInvokeWithDefaultPathWillLogMessageToConsole(): void
     {
         $handler = new AccessLogHandler();

--- a/tests/Io/LogStreamHandlerCliIsDevNull.php
+++ b/tests/Io/LogStreamHandlerCliIsDevNull.php
@@ -1,0 +1,11 @@
+<?php
+
+use FrameworkX\Io\LogStreamHandler;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$log = new LogStreamHandler($argv[1] ?? 'php://stdout');
+
+$buffer = var_export($log->isDevNull(), true) . PHP_EOL;
+
+file_put_contents($argv[2] ?? 'php://stdout', $buffer);

--- a/tests/Io/LogStreamHandlerCliIsDevNullAfterClose.php
+++ b/tests/Io/LogStreamHandlerCliIsDevNullAfterClose.php
@@ -1,0 +1,18 @@
+<?php
+
+use FrameworkX\Io\LogStreamHandler;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+fclose(STDOUT);
+
+try {
+    $log = new LogStreamHandler($argv[1] ?? 'php://stdout');
+} catch (\Exception $e) {
+    fwrite(STDERR, get_class($e) . ': ' . $e->getMessage() . PHP_EOL);
+    exit(1);
+}
+
+$buffer = var_export($log->isDevNull(), true) . PHP_EOL;
+
+file_put_contents($argv[2] ?? 'php://stdout', $buffer);


### PR DESCRIPTION
This changeset improves performance noticeable by skipping the `AccessLogHandler` if it writes to `/dev/null`. This is commonly used when the access log is not needed, such as when running behind a reverse proxy or when benchmarking the raw application performance.

This can be easily reproduced by running a benchmark against any of the examples like this:

```bash
$ php public/index.php >/dev/null
$ docker run -it --rm --net=host jordi/ab -n100000 -c100 -k http://localhost:8080/

# old: 22678 requests per second
# new: 29232 requests per second
```

(Also posted in https://twitter.com/another_clue/status/1764649661749690540)

This builds on top of the recent access log path additions from #247. In particular, this optimization works both when explicitly configured to log to `/dev/null` or when implicitly logging to console output that is piped to `/dev/null`.

This is a pure performance optimization that comes with 100% code coverage and does not otherwise affect the public API, so it should be safe to apply. This currently focuses on Unix-based platforms (Linux / Mac) as the main deployment target, but similar optimizations should be possible on Windows (using `nul` instead of `/dev/null`).

You're looking at several days worth of work, especially for testing this across multiple platforms. If you enjoy this change and want to help us continue to ship more improvements, consider supporting this project, for example by [becoming a sponsor](https://github.com/sponsors/clue) ❤️

Builds on top of #247
Refs #169