### PR TITLE
Consistent parsing for HTTP `CONNECT` request method (PHP SAPI)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=7.1",
         "nikic/fast-route": "^1.3",
         "react/async": "^4 || ^3",
-        "react/http": "^1.9",
+        "react/http": "^1.10",
         "react/promise": "^3 || ^2.10",
         "react/socket": "^1.13"
     },

--- a/src/Io/SapiHandler.php
+++ b/src/Io/SapiHandler.php
@@ -69,6 +69,8 @@ class SapiHandler
         $url = $target;
         if (($target[0] ?? '/') === '/' || $target === '*') {
             $url = (($_SERVER['HTTPS'] ?? null) === 'on' ? 'https://' : 'http://') . ($host ?? 'localhost') . ($target === '*' ? '' : $target);
+        } elseif (($_SERVER['REQUEST_METHOD'] ?? null) === 'CONNECT') {
+            $url = (($_SERVER['HTTPS'] ?? null) === 'on' ? 'https://' : 'http://') . $target;
         }
 
         $body = file_get_contents('php://input');

--- a/tests/Io/SapiHandlerTest.php
+++ b/tests/Io/SapiHandlerTest.php
@@ -133,7 +133,7 @@ class SapiHandlerTest extends TestCase
         $request = $sapi->requestFromGlobals();
 
         $this->assertEquals('CONNECT', $request->getMethod());
-        $this->assertEquals('example.com:443', (string) $request->getUri());
+        $this->assertEquals('//example.com:443', (string) $request->getUri());
         $this->assertEquals('example.com:443', $request->getRequestTarget());
         $this->assertEquals('1.1', $request->getProtocolVersion());
         $this->assertEquals('example.com:443', $request->getHeaderLine('Host'));

--- a/tests/Io/SapiHandlerTest.php
+++ b/tests/Io/SapiHandlerTest.php
@@ -133,7 +133,67 @@ class SapiHandlerTest extends TestCase
         $request = $sapi->requestFromGlobals();
 
         $this->assertEquals('CONNECT', $request->getMethod());
-        $this->assertEquals('//example.com:443', (string) $request->getUri());
+        $this->assertEquals('http://example.com:443', (string) $request->getUri());
+        $this->assertEquals('example.com:443', $request->getRequestTarget());
+        $this->assertEquals('1.1', $request->getProtocolVersion());
+        $this->assertEquals('example.com:443', $request->getHeaderLine('Host'));
+    }
+
+    /**
+     * @backupGlobals enabled
+     */
+    public function testRequestFromGlobalsWithConnectProxyWithDefaultHttpPort(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'CONNECT';
+        $_SERVER['REQUEST_URI'] = 'example.com:80';
+        $_SERVER['SERVER_PROTOCOL'] = 'http/1.1';
+        $_SERVER['HTTP_HOST'] = 'example.com';
+
+        $sapi = new SapiHandler();
+        $request = $sapi->requestFromGlobals();
+
+        $this->assertEquals('CONNECT', $request->getMethod());
+        $this->assertEquals('http://example.com', (string) $request->getUri());
+        $this->assertEquals('example.com:80', $request->getRequestTarget());
+        $this->assertEquals('1.1', $request->getProtocolVersion());
+        $this->assertEquals('example.com', $request->getHeaderLine('Host'));
+    }
+
+    /**
+     * @backupGlobals enabled
+     */
+    public function testRequestFromGlobalsWithConnectProxyWithoutHostHeader(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'CONNECT';
+        $_SERVER['REQUEST_URI'] = 'example.com:8080';
+        $_SERVER['SERVER_PROTOCOL'] = 'http/1.1';
+
+        $sapi = new SapiHandler();
+        $request = $sapi->requestFromGlobals();
+
+        $this->assertEquals('CONNECT', $request->getMethod());
+        $this->assertEquals('http://example.com:8080', (string) $request->getUri());
+        $this->assertEquals('example.com:8080', $request->getRequestTarget());
+        $this->assertEquals('1.1', $request->getProtocolVersion());
+        $this->assertFalse($request->hasHeader('Host'));
+    }
+
+    /**
+     * @backupGlobals enabled
+     */
+    public function testRequestFromGlobalsWithConnectProxyOverHttps(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'CONNECT';
+        $_SERVER['REQUEST_URI'] = 'example.com:443';
+        $_SERVER['SERVER_PROTOCOL'] = 'http/1.1';
+        $_SERVER['HTTP_HOST'] = 'example.com:443';
+        $_SERVER['HTTPS'] = 'on';
+
+        $sapi = new SapiHandler();
+        $request = $sapi->requestFromGlobals();
+
+        $this->assertEquals('CONNECT', $request->getMethod());
+        $this->assertEquals('https://example.com', (string) $request->getUri());
         $this->assertEquals('example.com:443', $request->getRequestTarget());
         $this->assertEquals('1.1', $request->getProtocolVersion());
         $this->assertEquals('example.com:443', $request->getHeaderLine('Host'));


### PR DESCRIPTION
This changeset improves consistency when parsing incoming HTTP proxy requests using the `CONNECT` request method when using the PHP SAPI. We already reject any such requests with a `400 Bad Request` error response consistently (see #46). On top of this, we now also consistently parse the request URI in case the request will be processed through any global request middleware handlers. This does not otherwise affect our public API and comes with full code coverage, so this should be safe to apply.

In particular, ReactPHP now ships a new PSR-7 implementation and no longer uses the dated RingCentral PSR-7 implementation. The updated tests are now in line with the requirements outlined by PSR-7 which are now properly enforced via https://github.com/reactphp/http/pull/521 and https://github.com/reactphp/http/pull/522. Specifically, a `CONNECT` request now uses a request URI with the appropriate scheme specified. The previous test used incorrect assumptions provided by the dated RingCentral PSR-7 implementation and has been in place ever since #46 has been merged several years ago.

Builds on top of #46, https://github.com/reactphp/http/pull/521, https://github.com/reactphp/http/pull/201, https://github.com/reactphp/http/pull/158 and others