### PR TITLE
Support for request method override

### DIFF
--- a/src/Io/SapiHandler.php
+++ b/src/Io/SapiHandler.php
@@ -94,7 +94,7 @@ class SapiHandler
 
         // Method override via POST _method "magic" parameter or X-HTTP-Method-Override header, only for POST requests
         $method_override = strtoupper($_POST["_method"] ?? $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ?? "");
-        if ($request->getMethod() === "POST" && in_array($method_override, ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT"], true)) {
+        if ($request->getMethod() === "POST" && in_array($method_override, ["PUT", "PATCH", "DELETE"], true)) {
             $request = $request->withMethod($method_override);
         }
 

--- a/src/Io/SapiHandler.php
+++ b/src/Io/SapiHandler.php
@@ -92,6 +92,12 @@ class SapiHandler
         }
         $request = $request->withParsedBody($_POST);
 
+        // Method override via POST _method "magic" parameter or X-HTTP-Method-Override header, only for POST requests
+        $method_override = strtoupper($_POST["_method"] ?? $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ?? "");
+        if ($request->getMethod() === "POST" && in_array($method_override, ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT"], true)) {
+            $request = $request->withMethod($method_override);
+        }
+
         // Content-Length / Content-Type are special <3
         if ($request->getHeaderLine('Content-Length') === '') {
             $request = $request->withoutHeader('Content-Length');

--- a/tests/Io/SapiHandlerTest.php
+++ b/tests/Io/SapiHandlerTest.php
@@ -478,4 +478,40 @@ class SapiHandlerTest extends TestCase
 
         $this->assertEquals(['Content-Type:', 'Content-Length: 0'], xdebug_get_headers());
     }
+
+    public function testRequestFromGlobalsObeysMagicMethodOverride(): void
+    {
+        header_remove();
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['_method'] = 'PUT';
+
+        $sapi = new SapiHandler();
+        $request = $sapi->requestFromGlobals();
+
+        $this->assertEquals('PUT', $request->getMethod());
+    }
+
+    public function testRequestFromGlobalsObeysXHttpMethodOverrideHeader(): void
+    {
+        header_remove();
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PUT';
+
+        $sapi = new SapiHandler();
+        $request = $sapi->requestFromGlobals();
+
+        $this->assertEquals('PUT', $request->getMethod());
+    }
+
+    public function testRequestFromGlobalsIgnoresInvalidMethodOverride(): void
+    {
+        header_remove();
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+        $_POST['_method'] = 'POST';
+
+        $sapi = new SapiHandler();
+        $request = $sapi->requestFromGlobals();
+
+        $this->assertEquals('PUT', $request->getMethod());
+    }
 }


### PR DESCRIPTION
SAPI: Added support for overriding the request method via either the X-HTTP-Method-Override header or _method "magic" parameter. This is useful due to known shortcomings of PHP itself not passing parameters for other methods than POST.

Example use case, email address change process:
1. Send out token to new email address via POST to /change-email
2. Confirm change by passing token + code to via PUT to /change-email

Currently not possible as the parsed body is empty (ReactPHP mimicks PHP's behaviour in that case). This also allows to use e.g. the DELETE verb in HTML form requests: via `<input type="hidden" name="_method" value="DELETE" />`