### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
     "require": {
         "php": ">=7.1",
         "nikic/fast-route": "^1.3",
-        "react/async": "^4 || ^3",
-        "react/http": "^1.10",
-        "react/promise": "^3",
-        "react/socket": "^1.14"
+        "react/async": "^4.3 || ^3",
+        "react/http": "^1.11",
+        "react/promise": "^3.2",
+        "react/socket": "^1.15"
     },
     "require-dev": {
         "phpstan/phpstan": "1.10.47 || 1.4.10",
         "phpunit/phpunit": "^9.6 || ^7.5",
         "psr/container": "^2 || ^1",
-        "react/promise-timer": "^1.10"
+        "react/promise-timer": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/src/Container.php
+++ b/src/Container.php
@@ -41,7 +41,7 @@ class Container
     }
 
     /** @return mixed */
-    public function __invoke(ServerRequestInterface $request, callable $next = null)
+    public function __invoke(ServerRequestInterface $request, ?callable $next = null)
     {
         if ($next === null) {
             // You don't want to end up here. This only happens if you use the
@@ -64,7 +64,7 @@ class Container
      */
     public function callable(string $class): callable
     {
-        return function (ServerRequestInterface $request, callable $next = null) use ($class) {
+        return function (ServerRequestInterface $request, ?callable $next = null) use ($class) {
             // Check `$class` references a valid class name that can be autoloaded
             if (\is_array($this->container) && !\class_exists($class, true) && !interface_exists($class, false) && !trait_exists($class, false)) {
                 throw new \BadMethodCallException('Request handler class ' . $class . ' not found');

--- a/src/Io/RouteHandler.php
+++ b/src/Io/RouteHandler.php
@@ -30,7 +30,7 @@ class RouteHandler
     /** @var Container */
     private $container;
 
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->routeCollector = new RouteCollector(new RouteParser(), new RouteGenerator());
         $this->errorHandler = new ErrorHandler();

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -169,7 +169,7 @@ class ContainerTest extends TestCase
             /** @var \stdClass|null|false */
             private $data = false;
 
-            public function __construct(\stdClass $data = null)
+            public function __construct(?\stdClass $data = null)
             {
                 $this->data = $data;
             }
@@ -199,7 +199,7 @@ class ContainerTest extends TestCase
             /** @var \stdClass|null|false */
             private $data = false;
 
-            public function __construct(\stdClass $data = null)
+            public function __construct(?\stdClass $data = null)
             {
                 $this->data = $data;
             }

--- a/tests/Io/RouteHandlerTest.php
+++ b/tests/Io/RouteHandlerTest.php
@@ -205,7 +205,7 @@ class RouteHandlerTest extends TestCase
         $controller = new class {
             /** @var ?Response */
             public static $response;
-            public function __construct(int $value = null)
+            public function __construct(?int $value = null)
             {
                 assert($value === null);
             }


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260.

Builds on top of #265, #255, #244, https://github.com/reactphp/promise/pull/260, https://github.com/reactphp/http/pull/537, https://github.com/reactphp/socket/pull/318, https://github.com/reactphp/async/pull/87 and https://github.com/reactphp/promise-timer/pull/70