### PR TITLE
Update documentation for `Dockerfile` syntax to avoid `BuildKit` warnings

### DIFF
--- a/docs/best-practices/deployment.md
+++ b/docs/best-practices/deployment.md
@@ -558,10 +558,10 @@ be achieved by using a `Dockerfile` with the following contents:
     COPY public/ public/
     COPY vendor/ vendor/
 
-    ENV X_LISTEN 0.0.0.0:8080
+    ENV X_LISTEN=0.0.0.0:8080
     EXPOSE 8080
 
-    ENTRYPOINT php public/index.php
+    ENTRYPOINT ["php", "public/index.php"]
     ```
 
 === "Dockerfile for minimal production image"
@@ -589,7 +589,7 @@ be achieved by using a `Dockerfile` with the following contents:
     # COPY src/ src/
     COPY --from=build /app/vendor/ vendor/
 
-    ENV X_LISTEN 0.0.0.0:8080
+    ENV X_LISTEN=0.0.0.0:8080
     EXPOSE 8080
 
     USER nobody:nobody

--- a/tests/integration/Dockerfile-basics
+++ b/tests/integration/Dockerfile-basics
@@ -5,7 +5,7 @@ WORKDIR /app/
 COPY public/ public/
 COPY vendor/ vendor/
 
-ENV X_LISTEN 0.0.0.0:8080
+ENV X_LISTEN=0.0.0.0:8080
 EXPOSE 8080
 
-ENTRYPOINT php public/index.php
+ENTRYPOINT ["php", "public/index.php"]

--- a/tests/integration/Dockerfile-production
+++ b/tests/integration/Dockerfile-production
@@ -23,7 +23,7 @@ COPY public/ public/
 # COPY src/ src/
 COPY --from=build /app/vendor/ vendor/
 
-ENV X_LISTEN 0.0.0.0:8080
+ENV X_LISTEN=0.0.0.0:8080
 EXPOSE 8080
 
 USER nobody:nobody


### PR DESCRIPTION
See https://docs.docker.com/reference/build-checks/
Builds on top of #267, #250, #150, #149 and others