### PR TITLE
Improve exception messages for `Container` to always match PHP 8+ format

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -372,8 +372,12 @@ class Container
     /** @throws void */
     private static function parameterError(\ReflectionParameter $parameter): string
     {
-        $name = $parameter->getDeclaringFunction()->getShortName();
-        if (!$parameter->getDeclaringFunction()->isClosure() && ($class = $parameter->getDeclaringClass()) !== null) {
+        $function = $parameter->getDeclaringFunction();
+        $name = $function->getShortName();
+        if ($name[0] === '{') { // $function->isAnonymous() (PHP 8.2+)
+            // use PHP 8.4+ format including closure file and line on all PHP versions: https://3v4l.org/tAs7s
+            $name = '{closure:' . $function->getFileName() . ':' . $function->getStartLine() . '}';
+        } elseif (($class = $parameter->getDeclaringClass()) !== null) {
             $name = explode("\0", $class->getName())[0] . '::' . $name;
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -381,7 +381,7 @@ class Container
             $name = explode("\0", $class->getName())[0] . '::' . $name;
         }
 
-        return 'Argument ' . ($parameter->getPosition() + 1) . ' ($' . $parameter->getName() . ') of ' . $name . '()';
+        return 'Argument #' . ($parameter->getPosition() + 1) . ' ($' . $parameter->getName() . ') of ' . $name . '()';
     }
 
     /**

--- a/src/Container.php
+++ b/src/Container.php
@@ -22,7 +22,7 @@ class Container
         /** @var mixed $loader explicit type check for mixed if user ignores parameter type */
         if (!\is_array($loader) && !$loader instanceof ContainerInterface) {
             throw new \TypeError(
-                'Argument #1 ($loader) must be of type array|Psr\Container\ContainerInterface, ' . (\is_object($loader) ? get_class($loader) : gettype($loader)) . ' given'
+                'Argument #1 ($loader) must be of type array|Psr\Container\ContainerInterface, ' . $this->gettype($loader) . ' given'
             );
         }
 
@@ -31,7 +31,7 @@ class Container
                 (!\is_object($value) && !\is_scalar($value) && $value !== null) ||
                 (!$value instanceof $name && !$value instanceof \Closure && !\is_string($value) && \strpos($name, '\\') !== false)
             ) {
-                throw new \BadMethodCallException('Map for ' . $name . ' contains unexpected ' . (is_object($value) ? get_class($value) : gettype($value)));
+                throw new \BadMethodCallException('Map for ' . $name . ' contains unexpected ' . $this->gettype($value));
             }
         }
         $this->container = $loader;
@@ -113,7 +113,7 @@ class Container
         }
 
         if (!\is_string($value) && $value !== null) {
-            throw new \TypeError('Environment variable $' . $name . ' expected type string|null, but got ' . (\is_object($value) ? \get_class($value) : \gettype($value)));
+            throw new \TypeError('Environment variable $' . $name . ' expected type string|null, but got ' . $this->gettype($value));
         }
 
         return $value;
@@ -166,7 +166,7 @@ class Container
                 // @phpstan-ignore-next-line because type of container value is explicitly checked after getting here
                 $value = $this->loadObject($this->container[$name], $depth - 1);
                 if (!$value instanceof $name) {
-                    throw new \BadMethodCallException('Factory for ' . $name . ' returned unexpected ' . \get_class($value));
+                    throw new \BadMethodCallException('Factory for ' . $name . ' returned unexpected ' . $this->gettype($value));
                 }
 
                 $this->container[$name] = $value;
@@ -187,12 +187,12 @@ class Container
                     $value = $this->loadObject($value, $depth - 1);
                 }
                 if (!$value instanceof $name) {
-                    throw new \BadMethodCallException('Factory for ' . $name . ' returned unexpected ' . (is_object($value) ? get_class($value) : gettype($value)));
+                    throw new \BadMethodCallException('Factory for ' . $name . ' returned unexpected ' . $this->gettype($value));
                 }
 
                 $this->container[$name] = $value;
             } elseif (!$this->container[$name] instanceof $name) {
-                throw new \BadMethodCallException('Map for ' . $name . ' contains unexpected ' . (\is_object($this->container[$name]) ? \get_class($this->container[$name]) : \gettype($this->container[$name])));
+                throw new \BadMethodCallException('Map for ' . $name . ' contains unexpected ' . $this->gettype($this->container[$name]));
             }
 
             assert($this->container[$name] instanceof $name);
@@ -329,7 +329,7 @@ class Container
             $value = $params === [] ? $factory() : $factory(...$params);
 
             if (!\is_object($value) && !\is_scalar($value) && $value !== null) {
-                throw new \BadMethodCallException('Container variable $' . $name . ' expected type object|scalar|null from factory, but got ' . \gettype($value));
+                throw new \BadMethodCallException('Container variable $' . $name . ' expected type object|scalar|null from factory, but got ' . $this->gettype($value));
             }
 
             $this->container[$name] = $value;
@@ -363,7 +363,7 @@ class Container
             (!\is_object($value) && !\in_array($type, ['string', 'int', 'float', 'bool'])) ||
             ($type === 'string' && !\is_string($value)) || ($type === 'int' && !\is_int($value)) || ($type === 'float' && !\is_float($value)) || ($type === 'bool' && !\is_bool($value))
         ) {
-            throw new \BadMethodCallException('Container variable $' . $name . ' expected type ' . $type . ', but got ' . (\is_object($value) ? \get_class($value) : \gettype($value)));
+            throw new \BadMethodCallException('Container variable $' . $name . ' expected type ' . $type . ', but got ' . $this->gettype($value));
         }
 
         return $value;
@@ -382,5 +382,25 @@ class Container
         }
 
         return 'Argument ' . ($parameter->getPosition() + 1) . ' ($' . $parameter->getName() . ') of ' . $name . '()';
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     * @throws void
+     * @see https://www.php.net/manual/en/function.get-debug-type.php (PHP 8+)
+     */
+    private function gettype($value): string
+    {
+        if (\is_int($value)) {
+            return 'int';
+        } elseif (\is_float($value)) {
+            return 'float';
+        } elseif (\is_bool($value)) {
+            return \var_export($value, true);
+        } elseif ($value === null) {
+            return 'null';
+        }
+        return \is_object($value) ? \get_class($value) : \gettype($value);
     }
 }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1529,25 +1529,25 @@ class AppTest extends TestCase
 
         yield [
             InvalidConstructorUntyped::class,
-            'Argument 1 ($value) of %s::__construct() has no type'
+            'Argument #1 ($value) of %s::__construct() has no type'
         ];
 
         yield [
             InvalidConstructorInt::class,
-            'Argument 1 ($value) of %s::__construct() expects unsupported type int'
+            'Argument #1 ($value) of %s::__construct() expects unsupported type int'
         ];
 
         if (PHP_VERSION_ID >= 80000) {
             yield [
                 InvalidConstructorUnion::class,
-                'Argument 1 ($value) of %s::__construct() expects unsupported type int|float'
+                'Argument #1 ($value) of %s::__construct() expects unsupported type int|float'
             ];
         }
 
         if (PHP_VERSION_ID >= 80100) {
             yield [
                 InvalidConstructorIntersection::class,
-                'Argument 1 ($value) of %s::__construct() expects unsupported type Traversable&amp;ArrayAccess'
+                'Argument #1 ($value) of %s::__construct() expects unsupported type Traversable&amp;ArrayAccess'
             ];
         }
 
@@ -1558,7 +1558,7 @@ class AppTest extends TestCase
 
         yield [
             InvalidConstructorSelf::class,
-            'Argument 1 ($value) of %s::__construct() is recursive'
+            'Argument #1 ($value) of %s::__construct() is recursive'
         ];
     }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1387,7 +1387,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(get_class($controller));
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Container variable $http expected type stdClass, but got integer');
+        $this->expectExceptionMessage('Container variable $http expected type stdClass, but got int');
         $callable($request);
     }
 
@@ -1412,7 +1412,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(get_class($controller));
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Container variable $http expected type string, but got integer');
+        $this->expectExceptionMessage('Container variable $http expected type string, but got int');
         $callable($request);
     }
 
@@ -1553,7 +1553,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(get_class($controller));
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Map for stdClass contains unexpected integer');
+        $this->expectExceptionMessage('Map for stdClass contains unexpected int');
         $callable($request);
     }
 
@@ -1575,7 +1575,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(get_class($controller));
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Map for stdClass contains unexpected NULL');
+        $this->expectExceptionMessage('Map for stdClass contains unexpected null');
         $callable($request);
     }
 
@@ -1597,7 +1597,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(get_class($controller));
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Map for stdClass contains unexpected NULL');
+        $this->expectExceptionMessage('Map for stdClass contains unexpected null');
         $callable($request);
     }
 
@@ -1678,7 +1678,7 @@ class ContainerTest extends TestCase
     public function testCtorThrowsWhenMapForClassContainsInvalidNull(): void
     {
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Map for Psr\Http\Message\ResponseInterface contains unexpected NULL');
+        $this->expectExceptionMessage('Map for Psr\Http\Message\ResponseInterface contains unexpected null');
 
         new Container([
             ResponseInterface::class => null
@@ -1711,7 +1711,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(\stdClass::class);
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Factory for stdClass returned unexpected integer');
+        $this->expectExceptionMessage('Factory for stdClass returned unexpected int');
         $callable($request);
     }
 
@@ -2087,7 +2087,7 @@ class ContainerTest extends TestCase
         ]);
 
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Environment variable $X_FOO expected type string|null, but got boolean');
+        $this->expectExceptionMessage('Environment variable $X_FOO expected type string|null, but got false');
         $container->getEnv('X_FOO');
     }
 
@@ -2133,7 +2133,7 @@ class ContainerTest extends TestCase
         $container = new Container($psr);
 
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Environment variable $X_FOO expected type string|null, but got integer');
+        $this->expectExceptionMessage('Environment variable $X_FOO expected type string|null, but got int');
         $container->getEnv('X_FOO');
     }
 
@@ -2263,10 +2263,39 @@ class ContainerTest extends TestCase
         $container($request);
     }
 
-    public function testCtorWithInvalidValueThrows(): void
+    public static function provideInvalidContainerConfigValues(): \Generator
+    {
+        yield [
+            (object) [],
+            \stdClass::class
+        ];
+        yield [
+            new Container([]),
+            Container::class
+        ];
+        yield [
+            true,
+            'true'
+        ];
+        yield [
+            false,
+            'false'
+        ];
+        yield [
+            1.0,
+            'float'
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidContainerConfigValues
+     * @param mixed $value
+     * @param string $type
+     */
+    public function testCtorWithInvalidValueThrows($value, string $type): void
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Argument #1 ($loader) must be of type array|Psr\Container\ContainerInterface, stdClass given');
-        new Container((object) []); // @phpstan-ignore-line
+        $this->expectExceptionMessage('Argument #1 ($loader) must be of type array|Psr\Container\ContainerInterface, ' . $type . ' given');
+        new Container($value); // @phpstan-ignore-line
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1285,7 +1285,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(get_class($controller));
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Argument 1 ($username) of {closure:' . __FILE__ . ':' . $line .'}() is not defined');
+        $this->expectExceptionMessage('Argument #1 ($username) of {closure:' . __FILE__ . ':' . $line .'}() is not defined');
         $callable($request);
     }
 
@@ -1641,7 +1641,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(get_class($controller));
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Argument 1 ($name) of class@anonymous::__construct() expects unsupported type string');
+        $this->expectExceptionMessage('Argument #1 ($name) of class@anonymous::__construct() expects unsupported type string');
         $callable($request);
     }
 
@@ -1772,7 +1772,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(\stdClass::class);
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Argument 1 ($undefined) of {closure:' . __FILE__ . ':' . $line .'}() has no type');
+        $this->expectExceptionMessage('Argument #1 ($undefined) of {closure:' . __FILE__ . ':' . $line .'}() has no type');
         $callable($request);
     }
 
@@ -1791,7 +1791,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(\stdClass::class);
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Argument 1 ($undefined) of {closure:' . __FILE__ . ':' . $line .'}() is not defined');
+        $this->expectExceptionMessage('Argument #1 ($undefined) of {closure:' . __FILE__ . ':' . $line .'}() is not defined');
         $callable($request);
     }
 
@@ -1807,7 +1807,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(\stdClass::class);
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Argument 1 ($data) of {closure:' . __FILE__ . ':' . $line .'}() is recursive');
+        $this->expectExceptionMessage('Argument #1 ($data) of {closure:' . __FILE__ . ':' . $line .'}() is recursive');
         $callable($request);
     }
 
@@ -2101,7 +2101,7 @@ class ContainerTest extends TestCase
         ]);
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Argument 1 ($extension) of extension_loaded() is not defined');
+        $this->expectExceptionMessage('Argument #1 ($extension) of extension_loaded() is not defined');
         $container->getEnv('X_FOO');
     }
 
@@ -2119,7 +2119,7 @@ class ContainerTest extends TestCase
         ]);
 
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Argument 1 ($bar) of class@anonymous::foo() is not defined');
+        $this->expectExceptionMessage('Argument #1 ($bar) of class@anonymous::foo() is not defined');
         $container->getEnv('X_FOO');
     }
 


### PR DESCRIPTION
Builds on top of #267, #244, #97, #95, #94, #92, #12 and others