### PR TITLE
[RFC] Update test environment and work around segfault with Xdebug 3.5.0-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ (matrix.os != 'windows-2022' || matrix.php < 8.2) && 'xdebug' || '' }} # temporarily skip Xdebug on Windows with PHP 8.2+ due to segfault with Xdebug 3.5.0-dev
           ini-file: development
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml
@@ -36,6 +36,7 @@ jobs:
       - run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
       - name: Check 100% code coverage
+        if: ${{ matrix.os != 'windows-2022' || matrix.php < 8.2 }} # temporarily skip coverage on Windows with PHP 8.2+ due to segfault with Xdebug 3.5.0-dev
         shell: php {0}
         run: |
           <?php

--- a/.github/workflows/deploy2website.yml
+++ b/.github/workflows/deploy2website.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - run: |
           curl -X POST -u ":${{ secrets.WEBSITE_PAT}}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/clue/framework-x-website/actions/workflows/ci.yml/dispatches -d '{"ref":"main"}'


### PR DESCRIPTION
This changeset updates the test environment to work around a segfault with Xdebug 3.5.0-dev. Right now, this causes an unrelated build error for all builds on Windows with PHP 8.2+ (see also https://github.com/clue/reactphp-redis/pull/173).

I wonder how widespread this problem would be exactly, as I don't see anything special that this project would execute (except perhaps for Fibers as of #117?). In either case, we should probably report this upstream to Xdebug and/or shivammathur/setup-php.

Builds on top of #267, #221 and https://github.com/clue/reactphp-redis/pull/173