### PR TITLE
Update CI/CD environment

### DIFF
--- a/.github/workflows/deploy2website.yml
+++ b/.github/workflows/deploy2website.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - run: |
           curl -X POST -u ":${{ secrets.WEBSITE_PAT}}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/clue/framework-x-website/actions/workflows/ci.yml/dispatches -d '{"ref":"main"}'


### PR DESCRIPTION
This trivial changeset updates the CI/CD environment to consistently use the latest versions.

Supersedes / closes #276 
Builds on top of #271, #267 and #32