### PR TITLE
Improve PHP 8.5+ support by updating to Promise v3.3 and avoiding deprecated `setAccessible()` calls in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "nikic/fast-route": "^1.3",
         "react/async": "^4.3 || ^3.1",
         "react/http": "^1.11",
-        "react/promise": "^3.2",
+        "react/promise": "^3.3",
         "react/socket": "^1.15"
     },
     "require-dev": {

--- a/tests/AccessLogHandlerTest.php
+++ b/tests/AccessLogHandlerTest.php
@@ -136,7 +136,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -154,7 +156,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GET', 'http://localhost:8080/?a=1&b=hello wörld', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -172,7 +176,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GE"T', 'http://localhost:8080/wörld', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -191,7 +197,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('HEAD', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -209,7 +217,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -227,7 +237,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -245,7 +257,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -264,7 +278,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('CONNECT', 'example.com:8080', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -283,7 +299,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('OPTIONS', 'http://example.com:8080', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -302,7 +320,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -320,7 +340,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -348,7 +370,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $stream = new ThroughStream();
@@ -369,7 +393,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $stream = new ThroughStream();
@@ -391,7 +417,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $stream = new ThroughStream();
@@ -411,7 +439,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $stream = new ThroughStream();
@@ -430,7 +460,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users', [], '', '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
@@ -449,7 +481,9 @@ class AccessLogHandlerTest extends TestCase
         $logger = $this->createMock(LogStreamHandler::class);
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         $request = new ServerRequest('GET', 'http://localhost:8080/users');

--- a/tests/AppMiddlewareTest.php
+++ b/tests/AppMiddlewareTest.php
@@ -27,7 +27,9 @@ class AppMiddlewareTest extends TestCase
         $router->expects($this->once())->method('map')->with(['GET'], '/', $middleware, $controller);
 
         $ref = new \ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->get('/', $middleware, $controller);
@@ -44,7 +46,9 @@ class AppMiddlewareTest extends TestCase
         $router->expects($this->once())->method('map')->with(['HEAD'], '/', $middleware, $controller);
 
         $ref = new \ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->head('/', $middleware, $controller);
@@ -61,7 +65,9 @@ class AppMiddlewareTest extends TestCase
         $router->expects($this->once())->method('map')->with(['POST'], '/', $middleware, $controller);
 
         $ref = new \ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->post('/', $middleware, $controller);
@@ -78,7 +84,9 @@ class AppMiddlewareTest extends TestCase
         $router->expects($this->once())->method('map')->with(['PUT'], '/', $middleware, $controller);
 
         $ref = new \ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->put('/', $middleware, $controller);
@@ -95,7 +103,9 @@ class AppMiddlewareTest extends TestCase
         $router->expects($this->once())->method('map')->with(['PATCH'], '/', $middleware, $controller);
 
         $ref = new \ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->patch('/', $middleware, $controller);
@@ -112,7 +122,9 @@ class AppMiddlewareTest extends TestCase
         $router->expects($this->once())->method('map')->with(['DELETE'], '/', $middleware, $controller);
 
         $ref = new \ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->delete('/', $middleware, $controller);
@@ -129,7 +141,9 @@ class AppMiddlewareTest extends TestCase
         $router->expects($this->once())->method('map')->with(['OPTIONS'], '/', $middleware, $controller);
 
         $ref = new \ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->options('/', $middleware, $controller);
@@ -146,7 +160,9 @@ class AppMiddlewareTest extends TestCase
         $router->expects($this->once())->method('map')->with(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], '/', $middleware, $controller);
 
         $ref = new \ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->any('/', $middleware, $controller);
@@ -163,7 +179,9 @@ class AppMiddlewareTest extends TestCase
         $router->expects($this->once())->method('map')->with(['GET', 'POST'], '/', $middleware, $controller);
 
         $ref = new \ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->map(['GET', 'POST'], '/', $middleware, $controller);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -42,12 +42,16 @@ class AppTest extends TestCase
         $app = new App($middleware);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -71,12 +75,16 @@ class AppTest extends TestCase
         $app = new App($container);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -87,7 +95,9 @@ class AppTest extends TestCase
 
         $routeHandler = $handlers[2];
         $ref = new ReflectionProperty($routeHandler, 'container');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $this->assertSame($container, $ref->getValue($routeHandler));
     }
 
@@ -102,12 +112,16 @@ class AppTest extends TestCase
         $app = new App($container, \stdClass::class);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -119,7 +133,9 @@ class AppTest extends TestCase
 
         $routeHandler = $handlers[3];
         $ref = new ReflectionProperty($routeHandler, 'container');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $this->assertSame($container, $ref->getValue($routeHandler));
     }
 
@@ -130,12 +146,16 @@ class AppTest extends TestCase
         $app = new App($errorHandler);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -150,12 +170,16 @@ class AppTest extends TestCase
         $app = new App(ErrorHandler::class);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -172,12 +196,16 @@ class AppTest extends TestCase
         $app = new App(new Container(), $errorHandler);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -198,12 +226,16 @@ class AppTest extends TestCase
         $app = new App($container, ErrorHandler::class);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -228,12 +260,16 @@ class AppTest extends TestCase
         $app = new App($unused, $container, ErrorHandler::class, $unused);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -259,12 +295,16 @@ class AppTest extends TestCase
         $app = new App($unused, $container, $middleware, $unused);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -283,12 +323,16 @@ class AppTest extends TestCase
         $app = new App($middleware, $errorHandler);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -322,12 +366,16 @@ class AppTest extends TestCase
         $app = new App($unused, $container1, $middleware, $container2, ErrorHandler::class, $unused);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -347,12 +395,16 @@ class AppTest extends TestCase
         $app = new App($accessLogHandler, $errorHandler);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -373,12 +425,16 @@ class AppTest extends TestCase
         $app = new App($accessLogHandler, $errorHandler);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -392,12 +448,16 @@ class AppTest extends TestCase
         $app = new App(AccessLogHandler::class, ErrorHandler::class);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -420,12 +480,16 @@ class AppTest extends TestCase
         $app = new App($container, AccessLogHandler::class, ErrorHandler::class);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -450,12 +514,16 @@ class AppTest extends TestCase
         $app = new App($container, AccessLogHandler::class, ErrorHandler::class);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -473,12 +541,16 @@ class AppTest extends TestCase
         $app = new App($middleware, $accessLog, $errorHandler);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -508,12 +580,16 @@ class AppTest extends TestCase
         $app = new App($unused, $container, AccessLogHandler::class, ErrorHandler::class, $unused);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -544,12 +620,16 @@ class AppTest extends TestCase
         $app = new App($unused, $container, $middleware, $unused);
 
         $ref = new ReflectionProperty($app, 'handler');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handler = $ref->getValue($app);
         assert($handler instanceof MiddlewareHandler);
 
         $ref = new ReflectionProperty($handler, 'handlers');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $handlers = $ref->getValue($handler);
         assert(is_array($handlers));
 
@@ -587,13 +667,17 @@ class AppTest extends TestCase
 
         // $sapi = $app->sapi;
         $ref = new \ReflectionProperty($app, 'sapi');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $sapi = $ref->getValue($app);
         assert($sapi instanceof ReactiveHandler);
 
         // $listenAddress = $sapi->listenAddress;
         $ref = new \ReflectionProperty($sapi, 'listenAddress');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $listenAddress = $ref->getValue($sapi);
 
         $this->assertEquals('0.0.0.0:8081', $listenAddress);
@@ -608,7 +692,9 @@ class AppTest extends TestCase
 
         // $app->sapi = $sapi;
         $ref = new \ReflectionProperty($app, 'sapi');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $sapi);
 
         $app->run();
@@ -622,7 +708,9 @@ class AppTest extends TestCase
         $router->expects($this->once())->method('map')->with(['GET'], '/', $this->anything());
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->get('/', function () { });
@@ -636,7 +724,9 @@ class AppTest extends TestCase
         $router->expects($this->once())->method('map')->with(['HEAD'], '/', $this->anything());
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->head('/', function () { });
@@ -650,7 +740,9 @@ class AppTest extends TestCase
         $router->expects($this->once())->method('map')->with(['POST'], '/', $this->anything());
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->post('/', function () { });
@@ -664,7 +756,9 @@ class AppTest extends TestCase
         $router->expects($this->once())->method('map')->with(['PUT'], '/', $this->anything());
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->put('/', function () { });
@@ -678,7 +772,9 @@ class AppTest extends TestCase
         $router->expects($this->once())->method('map')->with(['PATCH'], '/', $this->anything());
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->patch('/', function () { });
@@ -692,7 +788,9 @@ class AppTest extends TestCase
         $router->expects($this->once())->method('map')->with(['DELETE'], '/', $this->anything());
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->delete('/', function () { });
@@ -706,7 +804,9 @@ class AppTest extends TestCase
         $router->expects($this->once())->method('map')->with(['OPTIONS'], '/', $this->anything());
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->options('/', function () { });
@@ -720,7 +820,9 @@ class AppTest extends TestCase
         $router->expects($this->once())->method('map')->with(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], '/', $this->anything());
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->any('/', function () { });
@@ -734,7 +836,9 @@ class AppTest extends TestCase
         $router->expects($this->once())->method('map')->with(['GET', 'POST'], '/', $this->anything());
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->map(['GET', 'POST'], '/', function () { });
@@ -768,7 +872,9 @@ class AppTest extends TestCase
         }));
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->redirect('/', '/users');
@@ -800,7 +906,9 @@ class AppTest extends TestCase
         }));
 
         $ref = new ReflectionProperty($app, 'router');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($app, $router);
 
         $app->redirect('/', '/users', 307);

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -422,7 +422,9 @@ class ErrorHandlerTest extends TestCase
 
         // $response = $handler->errorInvalidException($e);
         $ref = new \ReflectionMethod($handler, 'errorInvalidException');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $response = $ref->invoke($handler, $e);
         assert($response instanceof ResponseInterface);
 
@@ -480,7 +482,9 @@ class ErrorHandlerTest extends TestCase
 
         // $response = $handler->errorInvalidResponse($value);
         $ref = new \ReflectionMethod($handler, 'errorInvalidResponse');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $response = $ref->invoke($handler, $value);
         assert($response instanceof ResponseInterface);
 
@@ -502,7 +506,9 @@ class ErrorHandlerTest extends TestCase
 
         // $response = $handler->errorInvalidCoroutine($value, $file, $line);
         $ref = new \ReflectionMethod($handler, 'errorInvalidCoroutine');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $response = $ref->invoke($handler, $value, $file, $line);
         assert($response instanceof ResponseInterface);
 

--- a/tests/Io/LogStreamHandlerTest.php
+++ b/tests/Io/LogStreamHandlerTest.php
@@ -200,7 +200,9 @@ class LogStreamHandlerTest extends TestCase
         $logger->log('Hello');
 
         $ref = new \ReflectionProperty($logger, 'stream');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $stream = $ref->getValue($logger);
         assert(is_resource($stream));
 

--- a/tests/Io/ReactiveHandlerTest.php
+++ b/tests/Io/ReactiveHandlerTest.php
@@ -30,7 +30,9 @@ class ReactiveHandlerTest extends TestCase
 
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         // lovely: remove socket server on next tick to terminate loop
@@ -63,7 +65,9 @@ class ReactiveHandlerTest extends TestCase
 
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         // lovely: remove socket server on next tick to terminate loop
@@ -90,7 +94,9 @@ class ReactiveHandlerTest extends TestCase
 
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         // lovely: remove socket server on next tick to terminate loop
@@ -116,7 +122,9 @@ class ReactiveHandlerTest extends TestCase
 
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         // lovely: remove socket server on next tick to terminate loop
@@ -153,7 +161,9 @@ class ReactiveHandlerTest extends TestCase
 
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         Loop::futureTick(function () use ($addr): void {
@@ -202,7 +212,9 @@ class ReactiveHandlerTest extends TestCase
 
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         Loop::futureTick(function () use ($addr, $logger): void {
@@ -270,7 +282,9 @@ class ReactiveHandlerTest extends TestCase
 
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         Loop::futureTick(function () use ($addr, $logger): void {
@@ -313,7 +327,9 @@ class ReactiveHandlerTest extends TestCase
 
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         Loop::futureTick(function () use ($logger) {
@@ -340,7 +356,9 @@ class ReactiveHandlerTest extends TestCase
 
         // $handler->logger = $logger;
         $ref = new \ReflectionProperty($handler, 'logger');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $logger);
 
         Loop::futureTick(function () use ($logger) {

--- a/tests/Io/RouteHandlerTest.php
+++ b/tests/Io/RouteHandlerTest.php
@@ -24,7 +24,9 @@ class RouteHandlerTest extends TestCase
         $router->expects($this->once())->method('addRoute')->with(['GET'], '/', $controller);
 
         $ref = new \ReflectionProperty($handler, 'routeCollector');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $router);
 
         $handler->map(['GET'], '/', $controller);
@@ -41,7 +43,9 @@ class RouteHandlerTest extends TestCase
         $router->expects($this->once())->method('addRoute')->with(['GET'], '/', new MiddlewareHandler([$middleware, $controller]));
 
         $ref = new \ReflectionProperty($handler, 'routeCollector');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $router);
 
         $handler->map(['GET'], '/', $middleware, $controller);
@@ -61,7 +65,9 @@ class RouteHandlerTest extends TestCase
         $router->expects($this->once())->method('addRoute')->with(['GET'], '/', $controller);
 
         $ref = new \ReflectionProperty($handler, 'routeCollector');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $router);
 
         $handler->map(['GET'], '/', \stdClass::class);
@@ -77,7 +83,9 @@ class RouteHandlerTest extends TestCase
         $router->expects($this->once())->method('addRoute')->with(['GET'], '/', $controller);
 
         $ref = new \ReflectionProperty($handler, 'routeCollector');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $router);
 
         $handler->map(['GET'], '/', new Container(), $controller);
@@ -96,7 +104,9 @@ class RouteHandlerTest extends TestCase
         $router->expects($this->once())->method('addRoute')->with(['GET'], '/', $controller);
 
         $ref = new \ReflectionProperty($handler, 'routeCollector');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($handler, $router);
 
         assert($container instanceof Container);


### PR DESCRIPTION
This changeset improves PHP 8.5+ support by updating to Promise v3.3 and avoiding deprecated `setAccessible()` calls in tests. With these changes applied, tests against the current PHP 8.5 RC pass without errors.

Builds on top of https://github.com/reactphp/promise/pull/264, #281, #265, #267 and others
Refs https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible and https://github.com/php/php-src/pull/19273