### PR TITLE
Update test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,7 @@ jobs:
           coverage: ${{ matrix.php < 8.0 && 'xdebug' || 'pcov' }}
           ini-file: development
       - run: composer install
-      - run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml
-        if: ${{ matrix.php >= 7.3 }}
-      - run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml -c phpunit.xml.legacy
-        if: ${{ matrix.php < 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml ${{ matrix.php < 7.3 && '-c phpunit.xml.legacy' || '' }}
       - name: Check 100% code coverage
         shell: php {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
         with:
           php-version: 8.5
       - run: composer install -d tests/integration/
-      - run: docker build -f tests/integration/${{ matrix.dockerfile }} tests/integration/
-      - run: docker run -d -p 8080:8080 -v "$PWD/composer.json":/app/composer.json $(docker images -q | head -n1)
+      - run: docker build -t fx -f tests/integration/${{ matrix.dockerfile }} tests/integration/
+      - run: docker run -d -p 8080:8080 -v "$PWD/composer.json":/app/composer.json fx
       - run: bash tests/await.bash
       - run: bash tests/integration.bash
       - run: docker stop $(docker ps -qn1)
@@ -129,8 +129,8 @@ jobs:
         with:
           php-version: 8.5
       - run: composer install -d tests/integration/
-      - run: docker build -f tests/integration/Dockerfile-basics tests/integration/
-      - run: docker run -d -p 8080:8080 -v "$PWD/composer.json":/app/composer.json $(docker images -q | head -n1)
+      - run: docker build -t fx -f tests/integration/Dockerfile-basics tests/integration/
+      - run: docker run -d -p 8080:8080 -v "$PWD/composer.json":/app/composer.json fx
       - run: docker run -d --net=host -v "$PWD/tests/integration/":/home/framework-x/ -v "$PWD"/tests/integration/${{ matrix.config.path }}:/etc/nginx/conf.d/default.conf nginx:stable-alpine
       - run: bash tests/await.bash http://localhost/
       - run: bash tests/integration.bash http://localhost/

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "1.12.32 || 1.4.10",
-        "phpunit/phpunit": "^9.6 || ^7.5",
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^7.5",
         "psr/container": "^2 || ^1"
     },
     "autoload": {


### PR DESCRIPTION
This changeset updates the test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5. This is needed to run the tests on legacy platforms due to recent upstream changes as discussed in https://github.com/clue/reactphp-redis/pull/180.

Builds on top of https://github.com/clue/reactphp-redis/pull/180 and #221 and others