### PR TITLE
Allow recursive container calls from factory functions

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -395,17 +395,15 @@ class Container
             \assert($factory instanceof \Closure);
             $closure = new \ReflectionFunction($factory);
 
-            // build list of factory parameters based on parameter types
+            // invoke factory with list of parameters
             // temporarily unset factory reference to allow loading recursive variables from environment
             try {
                 unset($this->container[$name]);
-                $params = $this->loadFunctionParams($closure, $depth - 1, true, '$' . $name);
+                $value = $factory(...$this->loadFunctionParams($closure, $depth - 1, true, '$' . $name));
             } finally {
                 $this->container[$name] = $factory;
             }
 
-            // invoke factory with list of parameters
-            $value = $factory(...$params);
             if (!\is_object($value) && !\is_scalar($value) && $value !== null) {
                 throw new \TypeError(
                     'Return value of ' . self::functionName($closure) . ' for $' . $name . ' must be of type object|string|int|float|bool|null, ' . $this->gettype($value) . ' returned'

--- a/src/Container.php
+++ b/src/Container.php
@@ -245,12 +245,17 @@ class Container
 
                 $this->container[$name] = $value;
             } elseif ($this->container[$name] instanceof \Closure) {
-                // build list of factory parameters based on parameter types
-                $closure = new \ReflectionFunction($this->container[$name]);
-                $params = $this->loadFunctionParams($closure, $depth, true, \explode("\0", $name)[0]);
+                $factory = $this->container[$name];
+                $closure = new \ReflectionFunction($factory);
 
                 // invoke factory with list of parameters
-                $value = $params === [] ? ($this->container[$name])() : ($this->container[$name])(...$params);
+                // temporarily unset factory reference to allow loading recursive variables from environment
+                try {
+                    unset($this->container[$name]);
+                    $value = $factory(...$this->loadFunctionParams($closure, $depth, true, \explode("\0", $name)[0]));
+                } finally {
+                    $this->container[$name] = $factory;
+                }
 
                 if (\is_string($value)) {
                     if ($depth < 1) {

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2126,6 +2126,28 @@ class ContainerTest extends TestCase
         $this->assertEquals('foo', $container->getEnv('X_FOO'));
     }
 
+    public function testGetEnvReturnsNullIfFactoryFunctionUsesRecursiveGetEnvForVariableNotSetInGlobalEnv(): void
+    {
+        $container = new Container([
+            'X_FOO' => function (Container $container) { return $container->getEnv('X_FOO'); }
+        ]);
+
+        $this->assertNull($container->getEnv('X_FOO'));
+    }
+
+    public function testGetEnvReturnsStringIfFactoryFunctionUsesRecursiveGetEnvForVariableSetInGlobalEnv(): void
+    {
+        $container = new Container([
+            'X_FOO' => function (Container $container) { return $container->getEnv('X_FOO'); }
+        ]);
+
+        $_ENV['X_FOO'] = 'foo';
+        $ret = $container->getEnv('X_FOO');
+        unset($_ENV['X_FOO']);
+
+        $this->assertEquals('foo', $ret);
+    }
+
     public function testGetEnvReturnsStringFromPsrContainer(): void
     {
         $psr = $this->createMock(ContainerInterface::class);


### PR DESCRIPTION
This changeset allows recursive container calls from factory functions for any variables or classes. On its own, this is rarely useful as the `Container` has no public API exposed at the moment. This is mostly done as an internal preparation at the moment, but may be exposed as part of our public API that allows us to reuse this logic for more classes in a follow-up.

```php
$_ENV['X_FOO'] = 'foo';

$container = new Container([
    'X_FOO' => fn(Container $container): string => $container->getEnv('X_FOO') ?? 'default'
]);

assert($container->getEnv('X_FOO') === 'foo');
```

Builds on top of #290, #289, #288, #96 and others