### PR TITLE
Throw `TypeError` when container factory returns `Closure`

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -413,6 +413,10 @@ class Container
                 throw new \TypeError(
                     'Return value of ' . self::functionName($closure) . ' for $' . $name . ' must be of type object|string|int|float|bool|null, ' . $this->gettype($value) . ' returned'
                 );
+            } elseif ($value instanceof \Closure) {
+                throw new \TypeError(
+                    'Return value of ' . self::functionName($closure) . ' for $' . $name . ' must not be of type Closure'
+                );
             }
 
             $this->container[$name] = $value;

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2266,6 +2266,22 @@ class ContainerTest extends TestCase
         $container->getEnv('X_FOO');
     }
 
+    public function testGetEnvThrowsIfFactoryFunctionReturnsInvalidClosure(): void
+    {
+        $line = __LINE__ + 2;
+        $container = new Container([
+            'X_FOO' => function () {
+                return function () {
+                    return 42;
+                };
+            }
+        ]);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Return value of {closure:' . __FILE__ . ':' . $line . '}() for $X_FOO must not be of type Closure');
+        $container->getEnv('X_FOO');
+    }
+
     public function testGetEnvThrowsIfFactoryFunctionReturnsInvalidInt(): void
     {
         $container = new Container([
@@ -2807,6 +2823,22 @@ class ContainerTest extends TestCase
 
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Return value of {closure:' . __FILE__ . ':' . $line . '}() for FrameworkX\AccessLogHandler must be of type FrameworkX\AccessLogHandler, null returned');
+        $container->getObject(AccessLogHandler::class);
+    }
+
+    public function testGetObjectThrowsIfFactoryFunctionReturnsInvalidClosure(): void
+    {
+        $line = __LINE__ + 2;
+        $container = new Container([
+            AccessLogHandler::class => function () {
+                return function () {
+                    return 42;
+                };
+            }
+        ]);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Return value of {closure:' . __FILE__ . ':' . $line . '}() for FrameworkX\AccessLogHandler must be of type FrameworkX\AccessLogHandler, Closure returned');
         $container->getObject(AccessLogHandler::class);
     }
 


### PR DESCRIPTION
This changeset adds improved type checking for container factory functions to ensure they return the expected value instead of a `Closure`. Factory functions in the container configuration remain fully supported and continue to work as before, but their return value must be a usable value (object, scalar, or null) rather than another function:

```php
$container = new Container([
    'X_VALID' => function () { // supported: factory returns a string value
        return 'bar';
    },
    'X_INVALID' => function () { // error: factory returns a Closure instead of the expected value
        return function () {
            return 'bar';
        };
    },
    'X_FOO' => function ($X_VALID, $X_INVALID) {
    
    };
]);
```

This includes a number of updated tests to verify correct behavior and avoid introducing any potential regressions, so this has 100% code coverage and should be safe to apply. For class-type factories, this case is already caught by the existing type checks. For variable factories, a `Closure` is technically an object and would previously pass the type checks silently but would trigger a different return value on the next invocation. This adds an explicit check to catch this early.

Builds on top of #301, #284 and others
