### PR TITLE
Update test environment to fix integration tests with nginx 1.30

### DIFF
--- a/tests/integration.bash
+++ b/tests/integration.bash
@@ -423,7 +423,12 @@ match "HTTP/.* 200"
 notmatch -i "\"Content-Type\""
 notmatch -i "\"Content-Length\""
 
+curl -v $base/headers -H Host:
+skipifnot "Server:" # skip PHP development server (serves Host-less HTTP/1.1)
+match "HTTP/.* 400"
+
 curl -v $base/headers -H User-Agent: -H Accept: -H Host: -10
+skipif "HTTP/.* 400" # skip nginx 1.29.7+ (default HTTP/1.1 to upstream requires Host)
 match "HTTP/.* 200"
 match "{}"
 
@@ -447,7 +452,7 @@ match "\"DNT\""
 notmatch "\"Dnt\""
 
 curl -v $base/headers -H 'V: a' -H 'V: b'
-skipif "Server: nginx" # skip nginx (last only) and PHP webserver (first only)
+skipif "Server: nginx" # skip nginx (last only) and PHP development server (first only)
 skipifnot "Server:"
 match "HTTP/.* 200"
 match "\"V\": \"a, b\""
@@ -467,7 +472,7 @@ match "HTTP/.* 400"
 
 curl -v --proxy $baseWithPort -p $base/debug
 skipif "CONNECT aborted" # skip PHP development server (rejects as "Malformed HTTP request")
-match "HTTP/.* 400"
+match "HTTP/.* 40[05]" # expect 400 or 405 (nginx 1.29.3+ rejects CONNECT with 405)
 
 # check HTTP redirects
 


### PR DESCRIPTION
This changeset updates the integration tests for two HTTP edge-case behaviors introduced when the `nginx:stable-alpine` image rolled forward to nginx 1.30. Both are expected interactions with how nginx now proxies to upstream and handles `CONNECT`, not changes in Framework X behavior, and the tests cover them through the suite's existing per-server skip mechanism, the same way it already handles other server-specific differences.

The 1.30 stable line picks up two changes from the nginx 1.29.x mainline. nginx 1.29.7 made HTTP/1.1 with keep-alive to upstream servers the default (nginx/nginx#1080, previously HTTP/1.0), so a Host-less HTTP/1.0 request now reaches the backend as HTTP/1.1, where a `Host` header is required. nginx 1.29.3 reworked `CONNECT` handling (nginx/nginx#935), so it now rejects proxied `CONNECT` requests with `405 Not Allowed` rather than `400 Bad Request`. Framework X handles both correctly, and a new assertion covers the HTTP/1.1 `Host` requirement explicitly.

Builds on top of #3, #46 and others