### PR TITLE
Support `array` type for container variables and factory functions

### DIFF
--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -282,9 +282,9 @@ $app = new FrameworkX\App($container);
 
 Factory functions used in the container configuration map may also reference
 variables defined in the container configuration. You may use any object or
-scalar or `null` value for container variables or factory functions that return
-any such value. This can be particularly useful when combining autowiring with
-some manual configuration like this:
+scalar or `array` or `null` value for container variables or factory functions
+that return any such value. This can be particularly useful when combining
+autowiring with some manual configuration like this:
 
 === "Scalar values"
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -14,14 +14,14 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class Container
 {
-    /** @var array<string,object|callable():(object|scalar|null)|scalar|null>|ContainerInterface */
+    /** @var array<string,object|callable():(object|scalar|array<mixed>|null)|scalar|array<mixed>|null>|ContainerInterface */
     private $container;
 
     /** @var bool */
     private $useProcessEnv;
 
     /**
-     * @param array<string,callable():(object|scalar|null) | object | scalar | null>|ContainerInterface $config
+     * @param array<string,callable():(object|scalar|array<mixed>|null) | object | scalar | array<mixed> | null>|ContainerInterface $config
      * @throws \TypeError if given $config is invalid
      */
     public function __construct($config = [])
@@ -39,9 +39,9 @@ class Container
                     'Argument #1 ($config) for key "' . $name . '" must be of type ' . $name . '|Closure|string, ' . $this->gettype($value) . ' given'
                 );
             }
-            if (!\is_object($value) && !\is_scalar($value) && $value !== null) {
+            if (!\is_object($value) && !\is_scalar($value) && !\is_array($value) && $value !== null) {
                 throw new \TypeError(
-                    'Argument #1 ($config) for key "' . $name . '" must be of type object|string|int|float|bool|null|Closure, ' . $this->gettype($value) . ' given'
+                    'Argument #1 ($config) for key "' . $name . '" must be of type object|string|int|float|bool|array|null|Closure, ' . $this->gettype($value) . ' given'
                 );
             }
         }
@@ -385,12 +385,12 @@ class Container
     }
 
     /**
-     * @return object|string|int|float|bool|null
+     * @return object|string|int|float|bool|array<mixed>|null
      * @throws \TypeError if container factory returns an unexpected type
      * @throws \Error if $name can not be loaded
      * @throws \Throwable if container factory function throws unexpected exception
      */
-    private function loadVariable(string $name, int $depth = 64) /*: object|string|int|float|bool|null (PHP 8.0+) */
+    private function loadVariable(string $name, int $depth = 64) /*: object|string|int|float|bool|array|null (PHP 8.0+) */
     {
         \assert($this->hasVariable($name));
         \assert(\is_array($this->container) || !$this->container->has($name));
@@ -409,9 +409,9 @@ class Container
                 $this->container[$name] = $factory;
             }
 
-            if (!\is_object($value) && !\is_scalar($value) && $value !== null) {
+            if (!\is_object($value) && !\is_scalar($value) && !\is_array($value) && $value !== null) {
                 throw new \TypeError(
-                    'Return value of ' . self::functionName($closure) . ' for $' . $name . ' must be of type object|string|int|float|bool|null, ' . $this->gettype($value) . ' returned'
+                    'Return value of ' . self::functionName($closure) . ' for $' . $name . ' must be of type object|string|int|float|bool|array|null, ' . $this->gettype($value) . ' returned'
                 );
             } elseif ($value instanceof \Closure) {
                 throw new \TypeError(
@@ -433,12 +433,12 @@ class Container
             \assert($this->useProcessEnv && $value !== false);
         }
 
-        \assert(\is_object($value) || \is_scalar($value) || $value === null);
+        \assert(\is_object($value) || \is_scalar($value) || \is_array($value) || $value === null);
         return $value;
     }
 
     /**
-     * @param object|string|int|float|bool|null $value
+     * @param object|string|int|float|bool|array<mixed>|null $value
      * @param \ReflectionType $type
      * @throws void
      */
@@ -470,6 +470,7 @@ class Container
             (\is_int($value) && $type === 'int') ||
             (\is_float($value) && $type === 'float') ||
             (\is_bool($value) && $type === 'bool') ||
+            (\is_array($value) && $type === 'array') ||
             (\is_iterable($value) && $type === 'iterable') ||
             (\is_callable($value) && $type === 'callable') ||
             ($value === true && $type === 'true') || // PHP 8.2+ standalone type

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -542,7 +542,7 @@ class ContainerTest extends TestCase
         $this->assertEquals('{"name":"Alice"}', (string) $response->getBody());
     }
 
-    /** @return list<list<\stdClass|string|null>> */
+    /** @return list<array{\stdClass|string|array<mixed>|null,string}> */
     public function provideMixedValue(): array
     {
         return [
@@ -555,6 +555,18 @@ class ContainerTest extends TestCase
                 '"Alice"'
             ],
             [
+                [],
+                '[]'
+            ],
+            [
+                ['a', 'b'],
+                '["a","b"]'
+            ],
+            [
+                ['name' => 'Alice'],
+                '{"name":"Alice"}'
+            ],
+            [
                 null,
                 'null'
             ]
@@ -563,7 +575,7 @@ class ContainerTest extends TestCase
 
     /**
      * @dataProvider provideMixedValue
-     * @param \stdClass|string|null $value
+     * @param \stdClass|string|array<mixed>|null $value
      */
     public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariable($value, string $json): void
     {
@@ -602,7 +614,7 @@ class ContainerTest extends TestCase
 
     /**
      * @dataProvider provideMixedValue
-     * @param \stdClass|string|null $value
+     * @param \stdClass|string|array<mixed>|null $value
      */
     public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresUntypedContainerVariableWithFactory($value, string $json): void
     {
@@ -644,7 +656,7 @@ class ContainerTest extends TestCase
     /**
      * @requires PHP 8
      * @dataProvider provideMixedValue
-     * @param \stdClass|string|null $value
+     * @param \stdClass|string|array<mixed>|null $value
      */
     public function testCallableReturnsCallableForClassNameWithDependencyMappedWithFactoryThatRequiresMixedContainerVariable($value, string $json): void
     {
@@ -1360,7 +1372,7 @@ class ContainerTest extends TestCase
         $callable = $container->callable(get_class($controller));
 
         $this->expectException(\Error::class);
-        $this->expectExceptionMessage('Return value of {closure:' . __FILE__ . ':' . $line . '}() for $http must be of type object|string|int|float|bool|null, resource returned');
+        $this->expectExceptionMessage('Return value of {closure:' . __FILE__ . ':' . $line . '}() for $http must be of type object|string|int|float|bool|array|null, resource returned');
         $callable($request);
     }
 
@@ -1648,20 +1660,10 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCtorThrowsWhenConfigContainsInvalidArray(): void
-    {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Argument #1 ($config) for key "all" must be of type object|string|int|float|bool|null|Closure, array given');
-
-        new Container([ // @phpstan-ignore-line
-            'all' => []
-        ]);
-    }
-
     public function testCtorThrowsWhenConfigContainsInvalidResource(): void
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Argument #1 ($config) for key "file" must be of type object|string|int|float|bool|null|Closure, resource given');
+        $this->expectExceptionMessage('Argument #1 ($config) for key "file" must be of type object|string|int|float|bool|array|null|Closure, resource given');
 
         new Container([ // @phpstan-ignore-line
             'file' => tmpfile()
@@ -1937,11 +1939,31 @@ class ContainerTest extends TestCase
         $this->assertEquals('ArrayObject', $container->getEnv('X_FOO'));
     }
 
+    public function testGetEnvReturnsStringFromFactoryFunctionWithArrayType(): void
+    {
+        $container = new Container([
+            'X_FOO' => function (array $items) { return implode(',', $items); },
+            'items' => ['a', 'b', 'c']
+        ]);
+
+        $this->assertEquals('a,b,c', $container->getEnv('X_FOO'));
+    }
+
     public function testGetEnvReturnsStringFromFactoryFunctionWithIterableType(): void
     {
         $container = new Container([
             'X_FOO' => function (iterable $items) { $s = ''; foreach ($items as $v) { $s .= $v; } return $s; },
             'items' => new \ArrayIterator([1, 2, 3])
+        ]);
+
+        $this->assertEquals('123', $container->getEnv('X_FOO'));
+    }
+
+    public function testGetEnvReturnsStringFromFactoryFunctionWithIterableTypeAndArrayValue(): void
+    {
+        $container = new Container([
+            'X_FOO' => function (iterable $items) { $s = ''; foreach ($items as $v) { $s .= $v; } return $s; },
+            'items' => [1, 2, 3]
         ]);
 
         $this->assertEquals('123', $container->getEnv('X_FOO'));
@@ -1955,6 +1977,16 @@ class ContainerTest extends TestCase
         ]);
 
         $this->assertEquals('ALICE', $container->getEnv('X_FOO'));
+    }
+
+    public function testGetEnvReturnsStringFromFactoryFunctionWithCallableTypeAndArrayValue(): void
+    {
+        $container = new Container([
+            'X_FOO' => function (callable $fn) { return $fn(); },
+            'fn' => [new \DateTimeZone('UTC'), 'getName']
+        ]);
+
+        $this->assertEquals('UTC', $container->getEnv('X_FOO'));
     }
 
     /**
@@ -2325,7 +2357,7 @@ class ContainerTest extends TestCase
         ]);
 
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Return value of {closure:' . __FILE__ . ':' . $line . '}() for $X_FOO must be of type object|string|int|float|bool|null, resource returned');
+        $this->expectExceptionMessage('Return value of {closure:' . __FILE__ . ':' . $line . '}() for $X_FOO must be of type object|string|int|float|bool|array|null, resource returned');
         $container->getEnv('X_FOO');
     }
 
@@ -2366,6 +2398,17 @@ class ContainerTest extends TestCase
 
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Return value of ' . Container::class . '::getEnv() for $X_FOO must be of type string|null, false returned');
+        $container->getEnv('X_FOO');
+    }
+
+    public function testGetEnvThrowsIfMapContainsInvalidArray(): void
+    {
+        $container = new Container([
+            'X_FOO' => ['a', 'b']
+        ]);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Return value of ' . Container::class . '::getEnv() for $X_FOO must be of type string|null, array returned');
         $container->getEnv('X_FOO');
     }
 
@@ -2577,6 +2620,19 @@ class ContainerTest extends TestCase
 
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Argument #1 ($data) of {closure:' . __FILE__ . ':' . $line . '}() for $X_FOO must be of type object, string given');
+        $container->getEnv('X_FOO');
+    }
+
+    public function testGetEnvThrowsWhenFactoryFunctionExpectsArrayTypeButWrongTypeGiven(): void
+    {
+        $line = __LINE__ + 2;
+        $container = new Container([
+            'X_FOO' => function (array $items) { return implode(',', $items); },
+            'items' => 'not-an-array'
+        ]);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument #1 ($items) of {closure:' . __FILE__ . ':' . $line . '}() for $X_FOO must be of type array, string given');
         $container->getEnv('X_FOO');
     }
 


### PR DESCRIPTION
This changeset adds support for the `array` type for `Container` variables and factory function parameters and return values. Previously, providing an `array` as a container variable or returning one from a factory function would throw a `TypeError`, even though `array` is a valid type.

```php
$container = new FrameworkX\Container([
    'settings' => ['debug' => true, 'name' => 'Acme'],
    Acme\Todo\UserController::class => function (array $settings) {
        return new Acme\Todo\UserController($settings);
    }
]);
```

This includes new test cases covering `array` values for container variables and factory functions, plus the interactions with the existing `iterable` and `callable` types and the `getEnv()` error path. This has 100% code coverage and should be safe to apply.

Builds on top of #303, #284, #182 and others