### PR TITLE
Support any type for container variables and factory functions

### DIFF
--- a/docs/best-practices/controllers.md
+++ b/docs/best-practices/controllers.md
@@ -281,10 +281,10 @@ $app = new FrameworkX\App($container);
 ```
 
 Factory functions used in the container configuration map may also reference
-variables defined in the container configuration. You may use any object or
-scalar or `array` or `null` value for container variables or factory functions
-that return any such value. This can be particularly useful when combining
-autowiring with some manual configuration like this:
+variables defined in the container configuration. You may use a value of any
+type for container variables or factory functions that return any such value.
+This can be particularly useful when combining autowiring with some manual
+configuration like this:
 
 === "Scalar values"
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -14,14 +14,14 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class Container
 {
-    /** @var array<string,object|callable():(object|scalar|array<mixed>|null)|scalar|array<mixed>|null>|ContainerInterface */
+    /** @var array<string,mixed>|ContainerInterface */
     private $container;
 
     /** @var bool */
     private $useProcessEnv;
 
     /**
-     * @param array<string,callable():(object|scalar|array<mixed>|null) | object | scalar | array<mixed> | null>|ContainerInterface $config
+     * @param array<string,mixed>|ContainerInterface $config
      * @throws \TypeError if given $config is invalid
      */
     public function __construct($config = [])
@@ -37,11 +37,6 @@ class Container
             if (!$value instanceof $name && !$value instanceof \Closure && !\is_string($value) && \strpos($name, '\\') !== false) {
                 throw new \TypeError(
                     'Argument #1 ($config) for key "' . $name . '" must be of type ' . $name . '|Closure|string, ' . $this->gettype($value) . ' given'
-                );
-            }
-            if (!\is_object($value) && !\is_scalar($value) && !\is_array($value) && $value !== null) {
-                throw new \TypeError(
-                    'Argument #1 ($config) for key "' . $name . '" must be of type object|string|int|float|bool|array|null|Closure, ' . $this->gettype($value) . ' given'
                 );
             }
         }
@@ -385,12 +380,12 @@ class Container
     }
 
     /**
-     * @return object|string|int|float|bool|array<mixed>|null
+     * @return mixed
      * @throws \TypeError if container factory returns an unexpected type
      * @throws \Error if $name can not be loaded
      * @throws \Throwable if container factory function throws unexpected exception
      */
-    private function loadVariable(string $name, int $depth = 64) /*: object|string|int|float|bool|array|null (PHP 8.0+) */
+    private function loadVariable(string $name, int $depth = 64) /*: mixed (PHP 8.0+) */
     {
         \assert($this->hasVariable($name));
         \assert(\is_array($this->container) || !$this->container->has($name));
@@ -409,11 +404,7 @@ class Container
                 $this->container[$name] = $factory;
             }
 
-            if (!\is_object($value) && !\is_scalar($value) && !\is_array($value) && $value !== null) {
-                throw new \TypeError(
-                    'Return value of ' . self::functionName($closure) . ' for $' . $name . ' must be of type object|string|int|float|bool|array|null, ' . $this->gettype($value) . ' returned'
-                );
-            } elseif ($value instanceof \Closure) {
+            if ($value instanceof \Closure) {
                 throw new \TypeError(
                     'Return value of ' . self::functionName($closure) . ' for $' . $name . ' must not be of type Closure'
                 );
@@ -433,12 +424,11 @@ class Container
             \assert($this->useProcessEnv && $value !== false);
         }
 
-        \assert(\is_object($value) || \is_scalar($value) || \is_array($value) || $value === null);
         return $value;
     }
 
     /**
-     * @param object|string|int|float|bool|array<mixed>|null $value
+     * @param mixed $value
      * @param \ReflectionType $type
      * @throws void
      */

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1348,34 +1348,6 @@ class ContainerTest extends TestCase
         $callable($request);
     }
 
-    public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesVariableMappedFromFactoryWithUnexpectedReturnType(): void
-    {
-        $request = new ServerRequest('GET', 'http://example.com/');
-
-        $controller = new class(new \stdClass()) {
-            public function __construct(\stdClass $data)
-            {
-                assert($data instanceof \stdClass);
-            }
-        };
-
-        $line = __LINE__ + 5;
-        $container = new Container([
-            \stdClass::class => function (string $http) {
-                return (object) ['name' => $http];
-            },
-            'http' => function () {
-                return tmpfile();
-            }
-        ]);
-
-        $callable = $container->callable(get_class($controller));
-
-        $this->expectException(\Error::class);
-        $this->expectExceptionMessage('Return value of {closure:' . __FILE__ . ':' . $line . '}() for $http must be of type object|string|int|float|bool|array|null, resource returned');
-        $callable($request);
-    }
-
     public function testCallableReturnsCallableThatThrowsWhenFactoryReferencesObjectVariableMappedFromFactoryWithReturnsUnexpectedInteger(): void
     {
         $request = new ServerRequest('GET', 'http://example.com/');
@@ -1658,16 +1630,6 @@ class ContainerTest extends TestCase
         $this->expectException(\Error::class);
         $this->expectExceptionMessage('Argument #1 ($name) of class@anonymous::__construct() requires container config with type string, none given');
         $callable($request);
-    }
-
-    public function testCtorThrowsWhenConfigContainsInvalidResource(): void
-    {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Argument #1 ($config) for key "file" must be of type object|string|int|float|bool|array|null|Closure, resource given');
-
-        new Container([ // @phpstan-ignore-line
-            'file' => tmpfile()
-        ]);
     }
 
     public function testCtorThrowsWhenConfigForClassContainsInvalidObject(): void
@@ -2019,6 +1981,26 @@ class ContainerTest extends TestCase
         $this->assertEquals('false', $container->getEnv('X_FOO'));
     }
 
+    public function testGetEnvReturnsStringFromFactoryFunctionWithResourceValue(): void
+    {
+        $container = new Container([
+            'X_FOO' => function ($stream) { return get_resource_type($stream); },
+            'stream' => tmpfile()
+        ]);
+
+        $this->assertEquals('stream', $container->getEnv('X_FOO'));
+    }
+
+    public function testGetEnvReturnsStringFromFactoryFunctionWithResourceValueFromFactoryFunction(): void
+    {
+        $container = new Container([
+            'X_FOO' => function ($stream) { return get_resource_type($stream); },
+            'stream' => function () { return tmpfile(); }
+        ]);
+
+        $this->assertEquals('stream', $container->getEnv('X_FOO'));
+    }
+
     /**
      * @requires PHP 8
      */
@@ -2347,20 +2329,6 @@ class ContainerTest extends TestCase
         $container->getEnv('X_FOO');
     }
 
-    public function testGetEnvThrowsIfFactoryFunctionReturnsInvalidResource(): void
-    {
-        $line = __LINE__ + 2;
-        $container = new Container([
-            'X_FOO' => function () {
-                return tmpfile();
-            }
-        ]);
-
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Return value of {closure:' . __FILE__ . ':' . $line . '}() for $X_FOO must be of type object|string|int|float|bool|array|null, resource returned');
-        $container->getEnv('X_FOO');
-    }
-
     public function testGetEnvThrowsIfFactoryFunctionReturnsInvalidClosure(): void
     {
         $line = __LINE__ + 2;
@@ -2620,6 +2588,19 @@ class ContainerTest extends TestCase
 
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Argument #1 ($data) of {closure:' . __FILE__ . ':' . $line . '}() for $X_FOO must be of type object, string given');
+        $container->getEnv('X_FOO');
+    }
+
+    public function testGetEnvThrowsWhenFactoryFunctionExpectsStringTypeButResourceGiven(): void
+    {
+        $line = __LINE__ + 2;
+        $container = new Container([
+            'X_FOO' => function (string $data) { return $data; },
+            'data' => tmpfile()
+        ]);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument #1 ($data) of {closure:' . __FILE__ . ':' . $line . '}() for $X_FOO must be of type string, resource given');
         $container->getEnv('X_FOO');
     }
 


### PR DESCRIPTION
This changeset updates the `Container` to accept a value of any type for container variables and factory function return values. Previously, values were restricted to objects, scalars, `array` and `null`, so providing any other value (such as a `resource`) would throw a `TypeError`. This removes that remaining restriction. Closures continue to be treated as factory functions rather than plain values.

```php
$container = new FrameworkX\Container([
    'stream' => STDERR,
    Acme\Todo\UserController::class => function ($stream) {
        return new Acme\Todo\UserController($stream);
    }
]);
```

This includes new test cases covering `resource` values for container variables and factory functions. This has 100% code coverage and should be safe to apply.

Builds on top of #306, #303, #302, #284, #182 and others